### PR TITLE
Elemental updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,4 @@ For developers, after reading through the introduction on this page, head over t
 
 License
 =======
-Copyright (c) 2014-2021 [Rancher Labs, Inc.](http://rancher.com)
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Check Elemental UI Apache License details [here](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # elemental-ui
-Rancher Extension for Elemental UI
+Rancher Extension used in [rancher/dashboard](https://github.com/rancher/dashboard) for Elemental/OS Management UI.
+
+
+## Running for Development
+This is what you probably want to get started.
+```bash
+# Install dependencies
+yarn install
+
+# For development, serve with hot reload at https://localhost:8005
+# using the endpoint for your Rancher API
+API=https://your-rancher yarn mem-dev
+# or put the variable into a .env file
+# Goto https://localhost:8005
+```
+
+## Building the extension for production
+Bump the app version on `package.json` file, then run:
+```bash
+# Build for production
+./scripts/publish -g 
+# add flag -f if you need to overwrite an existing version
+
+
+# If you need to test the built extension
+yarn serve-pkgs
+```
+
+## Contributing
+
+For developers, after reading through the introduction on this page, head over to our [Getting Started](./docs/developer/getting-started) guide to learn more.
+
+License
+=======
+Copyright (c) 2014-2021 [Rancher Labs, Inc.](http://rancher.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # elemental-ui
-Rancher Extension used in [rancher/dashboard](https://github.com/rancher/dashboard) for Elemental/OS Management UI.
+Rancher Extension used in [rancher/dashboard](https://github.com/rancher/dashboard) for [Elemental](https://rancher.github.io/elemental/)/OS Management UI.
 
 
 ## Running for Development

--- a/pkg/elemental/README.md
+++ b/pkg/elemental/README.md
@@ -1,3 +1,15 @@
 # OS Management Extension
 
-Adds support for OS Management to Rancher Manager.
+Adds support for OS Management to Rancher Manager through Elemental.
+
+
+Elemental is a software stack enabling a centralized, full cloud-native OS management with Kubernetes.
+
+Cluster Node OSes are built and maintained via container images through the Elemental Toolkit and installed on new hosts using the Elemental CLI.
+
+The Elemental Operator and the Rancher System Agent enable Rancher Manager to fully control Elemental clusters, from the installation and management of the OS on the Nodes to the provisioning of new K3s or RKE2 clusters in a centralized way.
+
+For more details take a look at the documentation regarding [Elemental](https://rancher.github.io/elemental/).
+
+
+**IMPORTANT NOTE**: In order to have access to OS Management in Rancher Manager, installation of the Elemental Operator is required. Instructions for installing it can be found [here](https://rancher.github.io/elemental/elementaloperatorchart-reference/).

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -177,10 +177,8 @@ export default {
     >
       <div class="col span-12">
         <h3>{{ t('elemental.machineRegistration.edit.imageSetup') }}</h3>
-        <p>
-          <span v-html="t('elemental.machineRegistration.edit.downloadMachineRegistrationFile', {}, true)"></span>
-          <AsyncButton class="ml-10" mode="download" @click="download" />
-        </p>
+        <p v-html="t('elemental.machineRegistration.edit.downloadMachineRegistrationFile', {}, true)" />
+        <AsyncButton class="mt-10" mode="download" @click="download" />
       </div>
     </div>
     <div
@@ -189,7 +187,7 @@ export default {
     >
       <div class="col span-12">
         <h3>{{ t('elemental.machineRegistration.create.configuration') }}</h3>
-        <NameNsDescription v-model="value" :mode="mode" :description-hidden="true" />
+        <NameNsDescription v-model="value" :mode="mode" :description-hidden="true" :namespaced="false" />
       </div>
     </div>
     <div class="row mb-20">
@@ -221,61 +219,55 @@ export default {
         </h3>
         <Tabbed>
           <Tab label-key="elemental.machineRegistration.create.machineInv" name="machine-inventory" :weight="3">
-            <div class="row">
-              <div class="col span-6">
-                <KeyValue
-                  key="labels"
-                  :value="value.machineInventoryLabels"
-                  :add-label="t('labels.addLabel')"
-                  :mode="mode"
-                  :title="t('labels.labels.title')"
-                  :read-allowed="false"
-                  :value-can-be-empty="true"
-                  @input="value.setLabels($event, 'machineInventoryLabels', true)"
-                />
-              </div>
-              <div class="spacer"></div>
-              <div class="col span-6">
-                <KeyValue
-                  key="annotations"
-                  :value="value.machineInventoryAnnotations"
-                  :add-label="t('labels.addAnnotation')"
-                  :mode="mode"
-                  :title="t('labels.annotations.title')"
-                  :read-allowed="false"
-                  :value-can-be-empty="true"
-                  @input="value.setAnnotations($event, 'machineInventoryAnnotations', true)"
-                />
-              </div>
+            <div class="row mb-30">
+              <KeyValue
+                key="labels"
+                :value="value.machineInventoryLabels"
+                :add-label="t('labels.addLabel')"
+                :mode="mode"
+                :title="t('labels.labels.title')"
+                :read-allowed="false"
+                :value-can-be-empty="true"
+                @input="value.setLabels($event, 'machineInventoryLabels', true)"
+              />
+            </div>
+            <div class="row mb-10">
+              <KeyValue
+                key="annotations"
+                :value="value.machineInventoryAnnotations"
+                :add-label="t('labels.addAnnotation')"
+                :mode="mode"
+                :title="t('labels.annotations.title')"
+                :read-allowed="false"
+                :value-can-be-empty="true"
+                @input="value.setAnnotations($event, 'machineInventoryAnnotations', true)"
+              />
             </div>
           </Tab>
           <Tab label-key="elemental.machineRegistration.create.machineReg" name="machine-reg" :weight="2">
-            <div class="row">
-              <div class="col span-6">
-                <KeyValue
-                  key="labels"
-                  :value="value.labels"
-                  :add-label="t('labels.addLabel')"
-                  :mode="mode"
-                  :title="t('labels.labels.title')"
-                  :read-allowed="false"
-                  :value-can-be-empty="true"
-                  @input="value.setLabels($event)"
-                />
-              </div>
-              <div class="spacer"></div>
-              <div class="col span-6">
-                <KeyValue
-                  key="annotations"
-                  :value="value.annotations"
-                  :add-label="t('labels.addAnnotation')"
-                  :mode="mode"
-                  :title="t('labels.annotations.title')"
-                  :read-allowed="false"
-                  :value-can-be-empty="true"
-                  @input="value.setAnnotations($event)"
-                />
-              </div>
+            <div class="row mb-30">
+              <KeyValue
+                key="labels"
+                :value="value.labels"
+                :add-label="t('labels.addLabel')"
+                :mode="mode"
+                :title="t('labels.labels.title')"
+                :read-allowed="false"
+                :value-can-be-empty="true"
+                @input="value.setLabels($event)"
+              />
+            </div>
+            <div class="row mb-10">
+              <KeyValue
+                key="annotations"
+                :value="value.annotations"
+                :add-label="t('labels.addAnnotation')"
+                :mode="mode"
+                :title="t('labels.annotations.title')"
+                :read-allowed="false"
+                :value-can-be-empty="true"
+                @input="value.setAnnotations($event)"
+              />
             </div>
           </Tab>
         </Tabbed>

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -47,7 +47,7 @@ export default {
   },
   data() {
     return {
-      cloudConfig:  typeof this.value.spec.config === 'string' ? this.value.spec.config : saferDump(this.value.spec.config),
+      cloudConfig:  typeof this.value.spec === 'string' ? this.value.spec : saferDump(this.value.spec),
       yamlErrors:   null
     };
   },
@@ -57,7 +57,7 @@ export default {
         try {
           const parsed = jsyaml.load(neu);
 
-          this.value.spec.config = parsed;
+          this.value.spec = parsed;
           this.yamlErrors = null;
         } catch (e) {
           this.yamlErrors = exceptionToErrorsArray(e);

--- a/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
@@ -89,7 +89,7 @@ export default {
     <div class="row mt-40 mb-20">
       <div class="col span-12 mb-20">
         <h3>{{ t('elemental.osimage.create.configuration') }}</h3>
-        <NameNsDescription v-model="value" :mode="mode" :description-hidden="true" />
+        <NameNsDescription v-model="value" :mode="mode" :description-hidden="true" :namespaced="false" />
       </div>
     </div>
     <div v-if="value.spec" class="row mb-20">

--- a/pkg/elemental/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/pkg/elemental/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1182,7 +1182,7 @@ export default {
     done() {
       let routeName = 'c-cluster-product-resource';
 
-      if ( this.mode === _CREATE && (this.provider === 'import' || this.provider === 'custom' || this.isElementalCluster) ) {
+      if ( this.mode === _CREATE && (this.provider === 'import' || this.provider === 'custom') ) {
         // Go show the registration command
         routeName = 'c-cluster-product-resource-namespace-id';
       }

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -72,7 +72,7 @@ export function init($plugin, store) {
     AGE
   ]);
 
-  weightType(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES, 7, true);
+  weightType(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES, 11, true);
   configureType(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES, {
     isCreatable: true,
     isEditable:  true,

--- a/pkg/elemental/models/elemental.cattle.io.machineregistration.js
+++ b/pkg/elemental/models/elemental.cattle.io.machineregistration.js
@@ -9,7 +9,7 @@ import ElementalResource from './elemental-resource';
 
 const DEFAULT_CREATION_YAML = `cloud-config:
   users:
-    name: root
+  - name: root
     passwd: root
 elemental:
   install:

--- a/pkg/elemental/models/elemental.cattle.io.machineregistration.js
+++ b/pkg/elemental/models/elemental.cattle.io.machineregistration.js
@@ -7,19 +7,20 @@ import { matchesSomeRegex } from '@shell/utils/string';
 import { ELEMENTAL_DEFAULT_NAMESPACE } from '../types';
 import ElementalResource from './elemental-resource';
 
-const DEFAULT_CREATION_YAML = `cloud-config:
-  users:
-  - name: root
-    passwd: root
-elemental:
-  install:
-    poweroff: true
-    device: /dev/nvme0n1`;
+const DEFAULT_CREATION_YAML = `config:
+  cloud-config:
+    users:
+    - name: root
+      passwd: root
+  elemental:
+    install:
+      poweroff: true
+      device: /dev/nvme0n1`;
 
 export default class MachineRegistration extends ElementalResource {
   applyDefaults(vm, mode) {
     if ( !this.spec ) {
-      Vue.set(this, 'spec', { config: DEFAULT_CREATION_YAML });
+      Vue.set(this, 'spec', DEFAULT_CREATION_YAML);
     }
     if ( !this.metadata || mode === _CREATE ) {
       Vue.set(this, 'metadata', { namespace: ELEMENTAL_DEFAULT_NAMESPACE });

--- a/pkg/elemental/utils/custom-routing.ts
+++ b/pkg/elemental/utils/custom-routing.ts
@@ -1,9 +1,10 @@
-import { LOCAL } from '@shell/config/query-params';
 import { ELEMENTAL_PRODUCT_NAME } from '../config/elemental-types';
+
+const BLANK_CLUSTER = '_';
 
 export const rootElementalRoute = () => ({
   name:    `${ ELEMENTAL_PRODUCT_NAME }-c-cluster`,
-  params: { product: ELEMENTAL_PRODUCT_NAME, cluster: LOCAL }
+  params: { product: ELEMENTAL_PRODUCT_NAME, cluster: BLANK_CLUSTER }
 });
 
 export const createElementalRoute = (name: string, params: Object) => ({


### PR DESCRIPTION
- update README for extension 
- remove namespace selector from create/edit views 
- use `blank cluster` for elemental routes to allow for standard users to access elemental ui
- move `download` machine reg button to next line
- update labels and annotations to have ui elements by rows instead of cols in `machine registration` create/edit view
- update hierarchy of side menus 
- change route after creating elemental cluster to go to the provisioning cluster list
- update cloud config with the correct notation for user name in `machine registration` create/edit view

FYI @nwmac 