### PR TITLE
update dashboard screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ API=https://your-rancher yarn mem-dev
 # Goto https://localhost:8005
 ```
 
+## Updating @shell package
+This is about updating the @shell package which is the base from rancher/dashboard
+```bash
+# Update
+yarn create @rancher/update
+```
+
 ## Building the extension for production
 Bump the app version on `package.json` file, then run:
 ```bash

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@rancher/components": "0.1.0-alpha.5",
-    "@rancher/shell": "^0.2.1",
+    "@rancher/shell": "^0.2.3",
     "@types/lodash": "4.14.184",
     "core-js": "3.21.1",
     "css-loader": "4.3.0"

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -14,7 +14,6 @@ import jsyaml from 'js-yaml';
 import { saferDump } from '@shell/utils/create-yaml';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
 import { exceptionToErrorsArray } from '@shell/utils/error';
-import { downloadFile } from '@shell/utils/download';
 
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
@@ -111,33 +110,11 @@ export default {
         component.updateValue(value);
       }
     },
-    async getMachineRegistrationData() {
-      const url = `${ window.location.origin }/elemental/registration/${ this.value.status.registrationToken }`;
-
-      try {
-        const inStore = this.$store.getters['currentStore']();
-        const res = await this.$store.dispatch(`${ inStore }/request`, { url, responseType: 'blob' });
-        const machineRegFileName = `${ this.value.metadata.name }_registrationURL.yaml`;
-
-        return {
-          data:     res.data,
-          fileName: machineRegFileName
-        };
-      } catch (e) {
-        return { error: e };
-      }
-    },
     async download(btnCb) {
-      const machineReg = await this.getMachineRegistrationData();
-
-      if (machineReg.data) {
-        try {
-          downloadFile(machineReg.fileName, machineReg.data, 'text/markdown; charset=UTF-8');
-          btnCb(true);
-        } catch (error) {
-          btnCb(false);
-        }
-      } else {
+      try {
+        await this.value.downloadMachineRegistration();
+        btnCb(true);
+      } catch (error) {
         btnCb(false);
       }
     }

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -1,7 +1,7 @@
 
 import { STATE, NAME as NAME_COL, AGE, NAMESPACE as NAMESPACE_COL } from '@shell/config/table-headers';
 import { ELEMENTAL_SCHEMA_IDS } from './config/elemental-types';
-import { ELEMENTAL_PRODUCT_GROUP, ELEMENTAL_TYPES } from './types';
+import { ELEMENTAL_TYPES } from './types';
 import { createElementalRoute, rootElementalRoute } from './utils/custom-routing';
 
 export function init($plugin, store) {
@@ -11,7 +11,6 @@ export function init($plugin, store) {
 
   // app in sidebar
   product({
-    ifHaveGroup:         ELEMENTAL_PRODUCT_GROUP,
     icon:                'os-management',
     inStore:             'management',
     removable:           false,

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -1,5 +1,7 @@
 product:
   elemental: OS Management
+  description: "Elemental is a software stack enabling a centralized, full cloud-native OS management with Kubernetes. <br><br> Cluster Node OSes are built and maintained via container images through the Elemental Toolkit and installed on new hosts using the Elemental CLI. <br><br> The Elemental Operator and the Rancher System Agent enable Rancher Manager to fully control Elemental clusters, from the installation and management of the OS on the Nodes to the provisioning of new K3s or RKE2 clusters in a centralized way."
+  notInstalled: It appears that the Elemental Operator is not installed. To install Elemental Operator please follow the instructions on the official <a target="blank" href="https://rancher.github.io/elemental/elementaloperatorchart-reference/" target="_blank" rel="noopener nofollow">documentation</a>.
 
 cluster:
   provider:
@@ -65,7 +67,6 @@ elemental:
     operations: Operations
     machineInventories: Machine Inventories
   dashboard:
-    title: Elemental
     manageReg: Manage Machine Registrations
     manageOsImageUpgrade: Manage OS Image Upgrades
     noMachineReg: There are currently no Machine Registrations available

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -1,7 +1,7 @@
 product:
   elemental: OS Management
   description: "Elemental is a software stack enabling a centralized, full cloud-native OS management with Kubernetes. <br><br> Cluster Node OSes are built and maintained via container images through the Elemental Toolkit and installed on new hosts using the Elemental CLI. <br><br> The Elemental Operator and the Rancher System Agent enable Rancher Manager to fully control Elemental clusters, from the installation and management of the OS on the Nodes to the provisioning of new K3s or RKE2 clusters in a centralized way."
-  notInstalled: It appears that the Elemental Operator is not installed. To install Elemental Operator please follow the instructions on the official <a target="blank" href="https://rancher.github.io/elemental/elementaloperatorchart-reference/" target="_blank" rel="noopener nofollow">documentation</a>.
+  notInstalled: The Elemental Operator is required to run the OS Management extension. To install it please follow the instructions on the official <a target="blank" href="https://rancher.github.io/elemental/elementaloperatorchart-reference/" target="_blank" rel="noopener nofollow">documentation</a>.
 
 cluster:
   provider:
@@ -73,6 +73,8 @@ elemental:
     noMachineRegAction: Create a Machine Registration
     noManageOs: There are currently no OS Image Upgrades available
     noManageOsAction: Create an OS Image Upgrade
+    used: Used
+    free: Free
     btnLabel:
       create: 
         elemental.cattle.io.machineregistration: Create Machine Registration

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -55,11 +55,19 @@ typeLabel:
       other {Managed OS Versions}
     }
   elementalClusters: Clusters
+
+asyncButton:
+  downloadMachineReg:
+    action: Download
+    waiting: Preparing..
+    success: Download
+
 description:
   elemental.cattle.io.machineregistration: Endpoints to connect Machines
   elemental.cattle.io.machineinventory: Machine connected to Elemental
   elemental.cattle.io.managedosimage: Containerized OS Images for Machines
   elementalClusters: Clusters managed by Elemental
+
 elemental:
   menuLabels:
     dashboard: Dashboard

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -5,6 +5,12 @@ cluster:
   provider:
     machineinventoryselectortemplate: Elemental
 
+tableHeaders:
+  osImage: OS Image
+  token: Token
+  downloadTableDashboard: ''
+  download: 'Download'
+
 typeLabel:
   elemental:  |-
     {count, plural,
@@ -55,21 +61,23 @@ description:
 elemental:
   menuLabels:
     dashboard: Dashboard
+    titleDashboard: OS Management Dashboard
     operations: Operations
     machineInventories: Machine Inventories
   dashboard:
     title: Elemental
+    manageReg: Manage Machine Registrations
+    manageOsImageUpgrade: Manage OS Image Upgrades
+    noMachineReg: There are currently no Machine Registrations available
+    noMachineRegAction: Create a Machine Registration
+    noManageOs: There are currently no OS Image Upgrades available
+    noManageOsAction: Create an OS Image Upgrade
     btnLabel:
       create: 
         elemental.cattle.io.machineregistration: Create Machine Registration
         elemental.cattle.io.machineinventory: Create Machine Inventory
         elemental.cattle.io.managedosimage: Create Managed OS Image
         elementalClusters: Create Elemental Cluster
-      manage: 
-        elemental.cattle.io.machineregistration: Manage Machine Registrations
-        elemental.cattle.io.machineinventory: Manage Machine Inventories
-        elemental.cattle.io.managedosimage: Manage Managed OS Images
-        elementalClusters: Manage Elemental Clusters
   osimage:
     create:
       configuration: Configuration

--- a/pkg/elemental/models/elemental.cattle.io.machineregistration.js
+++ b/pkg/elemental/models/elemental.cattle.io.machineregistration.js
@@ -110,16 +110,10 @@ export default class MachineRegistration extends ElementalResource {
   }
 
   async downloadMachineRegistration() {
-    let machineReg;
-
     try {
-      machineReg = await this.getMachineRegistrationData();
-    } catch (e) {
-      return Promise.reject(e);
-    }
+      const machineReg = await this.getMachineRegistrationData();
 
-    try {
-      downloadFile(machineReg.fileName, machineReg.data, 'text/markdown; charset=UTF-8');
+      return downloadFile(machineReg.fileName, machineReg.data, 'text/markdown; charset=UTF-8');
     } catch (e) {
       return Promise.reject(e);
     }

--- a/pkg/elemental/models/elemental.cattle.io.machineregistration.js
+++ b/pkg/elemental/models/elemental.cattle.io.machineregistration.js
@@ -92,10 +92,6 @@ export default class MachineRegistration extends ElementalResource {
     });
   }
 
-  get truncatedToken() {
-    return `${ this.status?.registrationToken.slice(0, 10) }...`;
-  }
-
   async getMachineRegistrationData() {
     const url = `${ window.location.origin }/elemental/registration/${ this.status.registrationToken }`;
 
@@ -109,17 +105,23 @@ export default class MachineRegistration extends ElementalResource {
         fileName: machineRegFileName
       };
     } catch (e) {
-      return { error: e };
+      return Promise.reject(e);
     }
   }
 
   async downloadMachineRegistration() {
-    const machineReg = await this.getMachineRegistrationData();
+    let machineReg;
+
+    try {
+      machineReg = await this.getMachineRegistrationData();
+    } catch (e) {
+      return Promise.reject(e);
+    }
 
     try {
       downloadFile(machineReg.fileName, machineReg.data, 'text/markdown; charset=UTF-8');
     } catch (e) {
-      return { error: e };
+      return Promise.reject(e);
     }
   }
 }

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -2,19 +2,31 @@
 import { allHash } from '@shell/utils/promise';
 import Loading from '@shell/components/Loading';
 import { CAPI } from '@shell/config/types';
+import { NAME } from '@shell/config/table-headers';
+import ResourceTable from '@shell/components/ResourceTable';
+import PercentageBar from '@shell/components/PercentageBar';
 import { ELEMENTAL_SCHEMA_IDS, ELEMENTAL_CLUSTER_PROVIDER } from '../config/elemental-types';
 import { createElementalRoute } from '../utils/custom-routing';
 import { filterForElementalClusters } from '../utils/elemental-utils';
 
+const MAX_ITEMS_PER_TABLE = 6;
+
 export default {
   name:       'Dashboard',
-  components: { Loading },
+  components: {
+    Loading, PercentageBar, ResourceTable
+  },
   async fetch() {
     const allDispatches = await allHash({
+      // needed for table
       machineRegistrations: this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
+      // needed for resource gauge
       machineInventories:   this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES }),
       rancherClusters:      this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
+      // needed for table
       managedOsImages:      this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
+      // needed to populate cluster name col on machine inventories list
+      machineInvSelector:   this.$store.dispatch(`management/findAll`, { type: ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR })
     });
 
     this.resourcesData = {};
@@ -23,9 +35,47 @@ export default {
     this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES] = allDispatches.machineInventories;
     this.resourcesData[this.ELEMENTAL_CLUSTERS] = filterForElementalClusters(allDispatches.rancherClusters);
     this.resourcesData[ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES] = allDispatches.managedOsImages;
+    this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR] = allDispatches.machineInvSelector;
   },
   data() {
-    return { ELEMENTAL_CLUSTERS: 'elementalClusters' };
+    return {
+      ELEMENTAL_CLUSTERS:       'elementalClusters',
+      machineInvCrd:            ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES,
+      machineRegTitle:          this.t(`typeLabel."${ ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }"`, { count: 2 }),
+      managedOsTitle:           this.t(`typeLabel."${ ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }"`, { count: 2 }),
+      machineRegListLocation:   createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
+      machineRegCreateLocation: createElementalRoute('resource-create', { resource: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
+      managedOsListLocation:    createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
+      managedOsCreateLocation:  createElementalRoute('resource-create', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
+      machineRegHeaders:        [
+        NAME,
+        {
+          name:     'token',
+          labelKey: 'tableHeaders.token',
+          value:    'truncatedToken',
+          getValue: row => row.truncatedToken,
+          sort:     'truncatedToken'
+        },
+        {
+          name:          'download',
+          labelKey:      'tableHeaders.downloadTableDashboard',
+          value:         this.t('tableHeaders.download')
+        },
+      ],
+      managedOsHeaders:  [
+        NAME,
+        {
+          name:     'osImage',
+          labelKey: 'tableHeaders.osImage',
+          value:    'spec.osImage',
+          getValue: row => row.spec?.osImage,
+          sort:     'spec.osImage'
+        }
+      ],
+      colorStops: {
+        0: '--success', 30: '--warning', 70: '--error'
+      }
+    };
   },
   computed: {
     cards() {
@@ -40,52 +90,64 @@ export default {
         query: { type: ELEMENTAL_CLUSTER_PROVIDER }
       };
 
-      const clusterManageRoute = {
-        name:   'c-cluster-product-resource',
-        params: {
-          resource: CAPI.RANCHER_CLUSTER,
-          product:  'manager',
-        }
-      };
-
       [
         ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
         ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES,
-        this.ELEMENTAL_CLUSTERS,
-        // hide for now, until it's more mature and we know how to integrate it with the whole flow...
-        // ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES
+        this.ELEMENTAL_CLUSTERS
       ].forEach((type) => {
         const obj = {
-          count:    this.resourcesData[type]?.length || 0,
-          title:    this.t(`typeLabel."${ type }"`, { count: 2 }),
-          desc:     this.t(`description."${ type }"`),
-          btnLabel: this.t(`elemental.dashboard.btnLabel.${ this.resourcesData[type]?.length ? 'manage' : 'create' }."${ type }"`),
-          btnRoute: createElementalRoute(`resource${ !this.resourcesData[type]?.length ? '-create' : '' }`, { resource: type })
+          type,
+          count:       this.resourcesData[type]?.length || 0,
+          title:       this.t(`typeLabel."${ type }"`, { count: 2 }),
+          btnLabel:    this.t(`elemental.dashboard.btnLabel.create."${ type }"`),
+          btnRoute:    createElementalRoute(`resource-create`, { resource: type }),
+          btnDisabled: false,
+          btnVisible:  true
         };
 
-        let btnDisabled;
-
-        switch (type) {
-        case ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS:
-          btnDisabled = false;
-          break;
-        case ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES:
-          btnDisabled = !this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS]?.length && !this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES]?.length;
-          break;
-        case this.ELEMENTAL_CLUSTERS:
-          btnDisabled = !this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES]?.length && !this.resourcesData[this.ELEMENTAL_CLUSTERS]?.length;
-          !this.resourcesData[type]?.length ? obj.btnRoute = clusterCreateRoute : obj.btnRoute = clusterManageRoute;
-          break;
-        case ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES:
-          btnDisabled = !this.resourcesData[this.ELEMENTAL_CLUSTERS]?.length && !this.resourcesData[ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES]?.length;
-          break;
+        if (type === this.ELEMENTAL_CLUSTERS) {
+          obj.btnRoute = clusterCreateRoute;
         }
 
-        obj.btnDisabled = btnDisabled;
         out.push(obj);
       });
 
       return out;
+    },
+    machineRegRows() {
+      const data = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS];
+
+      if (data.length > MAX_ITEMS_PER_TABLE) {
+        return data.slice(0, MAX_ITEMS_PER_TABLE);
+      }
+
+      return data;
+    },
+    managedOsRows() {
+      const data = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES];
+
+      if (data.length > MAX_ITEMS_PER_TABLE) {
+        return data.slice(0, MAX_ITEMS_PER_TABLE);
+      }
+
+      return data;
+    },
+    percentageBarValue() {
+      const total = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].length || 0;
+
+      if (!this.used || !total) {
+        return 0;
+      }
+
+      return (this.used * 100) / total;
+    },
+    free() {
+      return this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].length ? this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].length - this.used : 0;
+    },
+    used() {
+      const clusterAssignedInventories = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].filter(item => item.clusterName);
+
+      return clusterAssignedInventories.length || 0;
     }
   },
   methods: {
@@ -93,6 +155,9 @@ export default {
       if (!card.btnDisabled) {
         this.$router.replace(card.btnRoute);
       }
+    },
+    async downloadMachineReg(item) {
+      await item.downloadMachineRegistration();
     }
   },
 };
@@ -103,8 +168,9 @@ export default {
     <Loading v-if="$fetchState.pending" />
     <div v-else>
       <h1 class="title">
-        {{ t('elemental.menuLabels.dashboard') }}
+        {{ t('elemental.menuLabels.titleDashboard') }}
       </h1>
+      <!-- Top cards -->
       <div class="main-card-container">
         <div
           v-for="card, index in cards"
@@ -112,18 +178,99 @@ export default {
           class="card"
         >
           <div class="card-top-block">
-            <h2>{{ card.count }}</h2>
+            <h1>{{ card.count }}</h1>
             <p>{{ card.title }}</p>
           </div>
-          <span>{{ card.desc }}</span>
           <button
+            v-if="card.type !== machineInvCrd || (card.type === machineInvCrd && !card.count)"
             type="button"
-            class="btn role-primary"
+            class="btn role-secondary"
             :class="{disabled: card.btnDisabled}"
             @click="handleRoute(card)"
           >
             {{ card.btnLabel }}
           </button>
+          <div
+            v-else
+            class="used-percentage-container mt-10"
+          >
+            <div>
+              <p>Used<span>{{ used }}</span></p>
+              <p>Free<span>{{ free }}</span></p>
+            </div>
+            <PercentageBar
+              class="mt-10"
+              :value="percentageBarValue"
+              :color-stops="colorStops"
+            />
+          </div>
+        </div>
+      </div>
+      <!-- Tables -->
+      <div class="row mt-40 mb-40">
+        <div class="col span-6">
+          <div class="table-title-block">
+            <h3 class="mb-20">
+              {{ machineRegTitle }}
+            </h3>
+            <nuxt-link :to="machineRegListLocation">
+              {{ t('elemental.dashboard.manageReg') }}
+            </nuxt-link>
+          </div>
+          <div
+            v-if="machineRegRows.length === 0"
+            class="empty-table-state"
+          >
+            <p>{{ t('elemental.dashboard.noMachineReg') }}</p>
+            <nuxt-link :to="machineRegCreateLocation">
+              {{ t('elemental.dashboard.noMachineRegAction') }}
+            </nuxt-link>
+          </div>
+          <ResourceTable
+            v-else
+            :rows="machineRegRows"
+            :headers="machineRegHeaders"
+            :search="false"
+            :table-actions="false"
+            :row-actions="true"
+            key-field="key"
+          >
+            <template #col:download="{col, row}">
+              <td>
+                <a class="link" @click="downloadMachineReg(row)">
+                  {{ col.value }}
+                </a>
+              </td>
+            </template>
+          </ResourceTable>
+        </div>
+        <div class="col span-6">
+          <div class="table-title-block">
+            <h3 class="mb-20">
+              {{ managedOsTitle }}
+            </h3>
+            <nuxt-link :to="managedOsCreateLocation">
+              {{ t('elemental.dashboard.manageOsImageUpgrade') }}
+            </nuxt-link>
+          </div>
+          <div
+            v-if="managedOsRows.length === 0"
+            class="empty-table-state"
+          >
+            <p>{{ t('elemental.dashboard.noManageOs') }}</p>
+            <nuxt-link :to="managedOsListLocation">
+              {{ t('elemental.dashboard.noManageOsAction') }}
+            </nuxt-link>
+          </div>
+          <ResourceTable
+            v-else
+            :rows="managedOsRows"
+            :headers="managedOsHeaders"
+            :search="false"
+            :table-actions="false"
+            :row-actions="true"
+            key-field="key"
+          />
         </div>
       </div>
     </div>
@@ -145,49 +292,81 @@ export default {
     width: fit-content;
     display: flex;
     flex-direction: column;
-    margin: 0 40px 40px 0;
+    flex-grow: 1;
+    border: 1px solid var(--border);
+    margin: 0 10px;
+    padding: 20px;
+    height: 141px;
+
+    &:first-child {
+      margin-left: 0;
+    }
+    &:last-child {
+      margin-right: 0;
+    }
 
     .card-top-block {
       display: flex;
       align-items: center;
       margin-bottom: 20px;
 
-      h2 {
-        margin: 0 20px 0 0;
+      h1 {
+        margin: 0 15px 0 0;
         font-weight: bold;
       }
 
       p {
+        font-size: 18px;
         font-weight: bold;
       }
     }
 
-    span {
-      margin-bottom: 10px;
-      color: var(--disabled-text);
-    }
-
     button {
       justify-content: center;
+      width: fit-content;
+      font-weight: bold;
+      margin-top: 12px;
+    }
+  }
+
+  .used-percentage-container {
+    > div {
+      display: flex;
+      justify-content: space-between;
+
+      p {
+        // font-size: 12px;
+      }
+
+      span {
+        font-size: 12px;
+        padding-left: 10px;
+        color: var(--muted);
+      }
     }
   }
 }
 
-.elemental-empty-dashboard {
-  flex: 1;
+.link {
+  cursor: pointer;
+}
+
+.empty-table-state {
+  border: 1px solid var(--border);
+  border-radius: 4px;
   display: flex;
-  align-items: center;
-  justify-content: center;
   flex-direction: column;
-  min-height: 100%;
+  justify-content: center;
+  align-items: center;
+  padding: 60px 0;
 
-  .icon-fleet {
-    font-size: 100px;
-    color: var(--disabled-text);
+  p {
+    margin-bottom: 20px;
   }
+}
 
-  > p > span {
-    color: var(--disabled-text);
-  }
+.table-title-block {
+  display: flex;
+  justify-content: space-between;
 }
 </style>

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -32,8 +32,8 @@ export default {
     };
 
     // needed to check if operator is installed
-    if (this.$store.getters['cluster/canList'](CATALOG.APP)) {
-      requests.installedApps = this.$store.dispatch('cluster/findAll', { type: CATALOG.APP });
+    if (this.$store.getters['management/canList'](CATALOG.APP)) {
+      requests.installedApps = this.$store.dispatch('management/findAll', { type: CATALOG.APP });
     }
 
     const allDispatches = await allHash(requests);
@@ -57,8 +57,8 @@ export default {
   },
   data() {
     return {
-      isElementalOpInstalled:                false,
-      isElementalOpNotInstalledAndHasSchema: true,
+      isElementalOpInstalled:                true,
+      isElementalOpNotInstalledAndHasSchema: false,
       ELEMENTAL_CLUSTERS:                    'elementalClusters',
       machineInvCrd:                         ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES,
       machineRegTitle:                       this.t(`typeLabel."${ ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }"`, { count: 2 }),

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -187,6 +187,8 @@ export default {
         await item.downloadMachineRegistration();
         btnCb(true);
       } catch (e) {
+        console.error('Failed to download file', e); // eslint-disable-line no-console
+
         btnCb(false);
       }
     }
@@ -302,10 +304,10 @@ export default {
               </td>
             </template>
             <template #col:download="{row}">
-              <td>
+              <td class="download-machine-reg">
                 <AsyncButton
                   action-color="role-multi-action"
-                  mode="download"
+                  mode="downloadMachineReg"
                   @click="downloadMachineReg(row, $event)"
                 />
               </td>
@@ -466,6 +468,19 @@ export default {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+  }
+}
+
+::v-deep .main-tables-container {
+ .download-machine-reg {
+    display: flex;
+    justify-content: center;
+    height: 59px;
+    min-width: 130px;
+
+    .icon.icon-lg {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Fixes #29 
- update dashboard screen according to designs https://xd.adobe.com/view/0f0a9d4e-e04a-4462-8d56-441e50ad4d42-5a59/screen/eca70f39-c3c6-4a9e-9c13-3b69fdf416e7

**Screenshots**
<img width="2039" alt="Screenshot 2022-10-27 at 15 45 03" src="https://user-images.githubusercontent.com/97888974/198331270-01895c3b-7a8b-46d5-8fc1-e89fd362da61.png">
<img width="2039" alt="Screenshot 2022-10-27 at 15 44 44" src="https://user-images.githubusercontent.com/97888974/198331243-0e9670c9-d833-4b38-bce0-175a63e2e083.png">

_To test the following scenario, you must be a `standard` user with `elemental admin` role and uninstall `elemental-operator`_
<img width="1723" alt="Screenshot 2022-10-28 at 12 33 10" src="https://user-images.githubusercontent.com/97888974/198662150-acf8588c-c286-412f-b374-f8e29402937e.png">

_To test the following scenario, you must be an `admin` user and uninstall `elemental-operator`_
<img width="1723" alt="Screenshot 2022-10-28 at 12 33 25" src="https://user-images.githubusercontent.com/97888974/198662263-eaf62e2e-5ea4-4e8e-bdfa-0803e9121e9c.png">

