### PR TITLE
Elemental - Several improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@rancher/components": "0.1.0-alpha.5",
-    "@rancher/shell": "^0.2.3",
+    "@rancher/shell": "^0.2.5",
     "@types/lodash": "4.14.184",
     "core-js": "3.21.1",
     "css-loader": "4.3.0"

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -126,7 +126,12 @@ export default {
     >
       <div class="col span-12">
         <h3>{{ t('elemental.machineRegistration.create.configuration') }}</h3>
-        <NameNsDescription v-model="value" :mode="mode" :description-hidden="true" :namespaced="false" />
+        <NameNsDescription
+          v-model="value"
+          :mode="mode"
+          :description-hidden="true"
+          :namespaced="false"
+        />
       </div>
     </div>
     <div class="row mb-20">
@@ -148,7 +153,12 @@ export default {
             @selected="onFileSelected"
           />
         </div>
-        <Banner v-for="(err, i) in yamlErrors" :key="i" color="error" :label="err" />
+        <Banner
+          v-for="(err, i) in yamlErrors"
+          :key="i"
+          color="error"
+          :label="err"
+        />
       </div>
     </div>
     <div class="row mb-40">
@@ -157,7 +167,16 @@ export default {
           {{ t('elemental.machineRegistration.create.labelsAndAnnotations') }}
         </h3>
         <Tabbed>
-          <Tab label-key="elemental.machineRegistration.create.machineInv" name="machine-inventory" :weight="3">
+          <Tab
+            label-key="elemental.machineRegistration.create.machineInv"
+            name="machine-inventory"
+            :weight="3"
+          >
+            <Banner
+              class="mb-40"
+              color="info"
+              v-html="t('elemental.machineRegistration.create.labelsAndAnnotationsMachInvBanner', {}, true)"
+            />
             <div class="row mb-30">
               <KeyValue
                 key="labels"
@@ -183,7 +202,16 @@ export default {
               />
             </div>
           </Tab>
-          <Tab label-key="elemental.machineRegistration.create.machineReg" name="machine-reg" :weight="2">
+          <Tab
+            label-key="elemental.machineRegistration.create.machineReg"
+            name="machine-reg"
+            :weight="2"
+          >
+            <Banner
+              class="mb-40"
+              color="info"
+              v-html="t('elemental.machineRegistration.create.labelsAndAnnotationsMachRegBanner', {}, true)"
+            />
             <div class="row mb-30">
               <KeyValue
                 key="labels"

--- a/pkg/elemental/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/pkg/elemental/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -161,8 +161,10 @@ export default {
         return errors;
       }
     },
+    // handle emitted matched machine inventories on selector so that machine count
+    // on machine pool can be kept up to date
     updateMachineCount(val) {
-      this.value.pool.quantity = val;
+      this.value.pool.quantity = val || 1;
     }
   }
 };

--- a/pkg/elemental/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/pkg/elemental/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -160,6 +160,9 @@ export default {
 
         return errors;
       }
+    },
+    updateMachineCount(val) {
+      this.value.pool.quantity = val;
     }
   }
 };
@@ -224,6 +227,7 @@ export default {
       :pool-index="idx"
       :machine-pools="machinePools"
       @error="e=>errors = e"
+      @updateMachineCount="updateMachineCount"
     />
     <Banner v-else-if="value.configMissing" color="error" label-key="cluster.machinePool.configNotFound" />
     <Banner v-else color="info" label-key="cluster.machinePool.noAccessBanner" />

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -117,6 +117,8 @@ elemental:
       configuration: Configuration
       cloudConfiguration: Cloud Configuration
       labelsAndAnnotations: Labels And Annotations
+      labelsAndAnnotationsMachInvBanner: 'Labels and annotations to be added to the <b>MachineInventory</b> when a new machine is registered. These can be used to select the correct MachineInventory when creating clusters and also can be used as templates using SMBIOS data. <br> For reference on SMBIOS data check the official <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://rancher.github.io/elemental/smbios">documentation</a>.'
+      labelsAndAnnotationsMachRegBanner: 'Labels and annotations for the <b>MachineRegistration</b> item about to be created/edited.'
       readFromFile: Read from File
       name:
         label: Name

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -1,7 +1,8 @@
 product:
   elemental: OS Management
   description: "Elemental is a software stack enabling a centralized, full cloud-native OS management with Kubernetes. <br><br> Cluster Node OSes are built and maintained via container images through the Elemental Toolkit and installed on new hosts using the Elemental CLI. <br><br> The Elemental Operator and the Rancher System Agent enable Rancher Manager to fully control Elemental clusters, from the installation and management of the OS on the Nodes to the provisioning of new K3s or RKE2 clusters in a centralized way."
-  notInstalled: The Elemental Operator is required to run the OS Management extension. To install it please follow the instructions on the official <a target="blank" href="https://rancher.github.io/elemental/elementaloperatorchart-reference/" target="_blank" rel="noopener nofollow">documentation</a>.
+  notInstalledOrNoSchema: Either the user doesn't have enough permissions to run the OS Management extension or the Elemental Operator is not installed (required to run the OS Management extension). <br><br> For user permissions, check with your Rancher administrator if the correct role is assigned. To install Elemental Operator please follow the instructions on the official <a target="blank" href="https://rancher.github.io/elemental/elementaloperatorchart-reference/" target="_blank" rel="noopener nofollow">documentation</a>.
+  notInstalledHasSchema: The Elemental Operator is required to run the OS Management extension. To install it please follow the instructions on the official <a target="blank" href="https://rancher.github.io/elemental/elementaloperatorchart-reference/" target="_blank" rel="noopener nofollow">documentation</a>.
 
 cluster:
   provider:
@@ -89,6 +90,8 @@ elemental:
         elemental.cattle.io.machineinventory: Create Machine Inventory
         elemental.cattle.io.managedosimage: Create Managed OS Image
         elementalClusters: Create Elemental Cluster
+      manage: 
+        elementalClusters: Manage Elemental Clusters
   osimage:
     create:
       configuration: Configuration

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -22,38 +22,38 @@ typeLabel:
     }
   elemental.cattle.io.machineinventoryselectortemplate: |-
     {count, plural,
-      one {Mach. Inv. Selec. Template}
-      other {Mach. Inv. Selec. Templates}
+      one {Inv. of Mach. Selec. Template}
+      other {Inv. of Mach. Selec. Templates}
     }
   elemental.cattle.io.machineinventoryselector: |-
     {count, plural,
-      one {Mach. Inv. Selector}
-      other {Mach. Inv. Selectors}
+      one {Inv. of Mach. Selector}
+      other {Inv. of Mach. Selectors}
     }
   elemental.cattle.io.machineinventory: |-
     {count, plural,
-      one {Machine Inventory}
-      other {Machine Inventories}
+      one {Inventory of Machines}
+      other {Inventory of Machines}
     }
   elemental.cattle.io.machineregistration: |-
     {count, plural,
-      one {Machine Registration}
-      other {Machine Registrations}
+      one {Registration Endpoint}
+      other {Registration Endpoints}
     }
   elemental.cattle.io.managedosimage: |-
     {count, plural,
-      one {OS Image Upgrade}
-      other {OS Image Upgrades}
+      one {Update Group}
+      other {Update Groups}
     }
   elemental.cattle.io.managedosversionchannel: |-
     {count, plural,
-      one {Managed OS Version Channel}
-      other {Managed OS Version Channels}
+      one {OS Version Channel}
+      other {OS Version Channels}
     }
   elemental.cattle.io.managedosversion: |-
     {count, plural,
-      one {Managed OS Version}
-      other {Managed OS Versions}
+      one {OS Version}
+      other {OS Versions}
     }
   elementalClusters: Clusters
 
@@ -74,24 +74,24 @@ elemental:
     dashboard: Dashboard
     titleDashboard: OS Management Dashboard
     operations: Operations
-    machineInventories: Machine Inventories
+    machineInventories: Inventory of Machines
   dashboard:
-    manageReg: Manage Machine Registrations
-    manageOsImageUpgrade: Manage OS Image Upgrades
-    noMachineReg: There are currently no Machine Registrations available
-    noMachineRegAction: Create a Machine Registration
-    noManageOs: There are currently no OS Image Upgrades available
-    noManageOsAction: Create an OS Image Upgrade
+    manageReg: Manage Registration Endpoints
+    manageOsImageUpgrade: Manage Update Groups
+    noMachineReg: There are currently no Registration Endpoints available
+    noMachineRegAction: Create a Registration Endpoint
+    noManageOs: There are currently no Update Groups available
+    noManageOsAction: Create an Update Group
     used: Used
     free: Free
     btnLabel:
       create: 
-        elemental.cattle.io.machineregistration: Create Machine Registration
-        elemental.cattle.io.machineinventory: Create Machine Inventory
+        elemental.cattle.io.machineregistration: Create Registration Endpoint
+        elemental.cattle.io.machineinventory: Create Inventory of Machines
         elemental.cattle.io.managedosimage: Create Managed OS Image
         elementalClusters: Create Elemental Cluster
       manage: 
-        elemental.cattle.io.machineregistration: Manage Machine Registrations
+        elemental.cattle.io.machineregistration: Manage Registration Endpoints
         elementalClusters: Manage Elemental Clusters
   osimage:
     create:
@@ -109,7 +109,7 @@ elemental:
   machineRegistration:
     edit:
       imageSetup: Setting up an OS image
-      downloadMachineRegistrationFile: 'Download the machine registration file and follow the set of instructions on how to prepare your ISO image <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://rancher.github.io/elemental/quickstart/#preparing-the-iso">here</a>.'
+      downloadMachineRegistrationFile: 'Download the Registration Endpoint file and follow the set of instructions on how to prepare your ISO image <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://rancher.github.io/elemental/quickstart/#preparing-the-iso">here</a>.'
     create:
       registrationToken: Registration Token
       registrationURL: 
@@ -124,19 +124,19 @@ elemental:
       name:
         label: Name
         placeholder: Enter a name
-      machineReg: Machine Registration
-      machineInv: Machine Inventories
+      machineReg: Registration Endpoint
+      machineInv: Inventory of Machines
   clusterGroup:
     selector:
-      label: Machine Inventory Selector Template
-      matchesAll: Matches all {total, number} existing Machine Inventories
-      matchesNone: Matches no existing Machine Inventories
+      label: Inventory of Machines Selector Template
+      matchesAll: Matches all {total, number} existing Inventory of Machines
+      matchesNone: Matches no existing Inventory of Machines
       matchesSome: |-
         {matched, plural,
-          =1 {Matches 1 of {total, number} existing Machine Inventories: "{sample}"}
-          other {Matches {matched, number} of {total, number} existing Machine Inventories, including "{sample}"}
+          =1 {Matches 1 of {total, number} existing Inventory of Machines: "{sample}"}
+          other {Matches {matched, number} of {total, number} existing Inventory of Machines, including "{sample}"}
         }
   machineInventory:
     createCluster: Create Elemental Cluster
     import: YAML import
-    updateForCreateClusterError: Error updating machine inventories with label for creating a cluster
+    updateForCreateClusterError: Error updating Inventory of Machines with label for creating a cluster

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -91,6 +91,7 @@ elemental:
         elemental.cattle.io.managedosimage: Create Managed OS Image
         elementalClusters: Create Elemental Cluster
       manage: 
+        elemental.cattle.io.machineregistration: Manage Machine Registrations
         elementalClusters: Manage Elemental Clusters
   osimage:
     create:

--- a/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
+++ b/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
@@ -92,7 +92,7 @@ export default {
       this.updateMatchingMachineInventories();
     },
 
-    updateMatchingMachineInventories: throttle(function(isFirstRun) {
+    updateMatchingMachineInventories: throttle(function() {
       const all = this.machineInventories;
       const match = matching(all, this.expressions);
       const matched = match.length || 0;

--- a/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
+++ b/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
@@ -18,7 +18,7 @@ export default {
         value: item
       };
     });
-    this.updateMatchingMachineInventories(true);
+    this.updateMatchingMachineInventories();
   },
   data() {
     if ( !this.value.spec?.template?.spec?.selector ) {
@@ -106,9 +106,9 @@ export default {
         sample,
       };
 
-      if (isFirstRun) {
-        this.$emit('updateMachineCount', matched);
-      }
+      // emit matched machine inventories on selector so that machine count
+      // on machine pool can be kept up to date
+      this.$emit('updateMachineCount', matched);
     }, 250, { leading: true })
   },
 };

--- a/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
+++ b/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
@@ -18,7 +18,7 @@ export default {
         value: item
       };
     });
-    this.updateMatchingMachineInventories();
+    this.updateMatchingMachineInventories(true);
   },
   data() {
     if ( !this.value.spec?.template?.spec?.selector ) {
@@ -92,7 +92,7 @@ export default {
       this.updateMatchingMachineInventories();
     },
 
-    updateMatchingMachineInventories: throttle(function() {
+    updateMatchingMachineInventories: throttle(function(isFirstRun) {
       const all = this.machineInventories;
       const match = matching(all, this.expressions);
       const matched = match.length || 0;
@@ -105,6 +105,10 @@ export default {
         isNone:  matched === 0,
         sample,
       };
+
+      if (isFirstRun) {
+        this.$emit('updateMachineCount', matched);
+      }
     }, 250, { leading: true })
   },
 };

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -134,16 +134,15 @@ export default {
           type,
           count:       this.resourcesData[type]?.length || 0,
           title:       this.t(`typeLabel."${ type }"`, { count: 2 }),
-          btnLabel:    this.t(`elemental.dashboard.btnLabel.create."${ type }"`),
-          btnRoute:    createElementalRoute(`resource-create`, { resource: type }),
+          btnLabel:    this.t(`elemental.dashboard.btnLabel.${ this.resourcesData[type]?.length ? 'manage' : 'create' }."${ type }"`),
+          btnRoute:    createElementalRoute(`resource${ !this.resourcesData[type]?.length ? '-create' : '' }`, { resource: type }),
           btnDisabled: false,
           btnVisible:  true
         };
 
         if (type === this.ELEMENTAL_CLUSTERS && obj.count > 0) {
           obj.btnRoute = clusterManageRoute;
-          obj.btnLabel = this.t(`elemental.dashboard.btnLabel.manage."${ type }"`);
-        } else {
+        } else if (type === this.ELEMENTAL_CLUSTERS) {
           obj.btnRoute = clusterCreateRoute;
         }
 

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -116,6 +116,15 @@ export default {
         query: { type: ELEMENTAL_CLUSTER_PROVIDER }
       };
 
+      const clusterManageRoute = {
+        name:   'c-cluster-product-resource',
+        params: {
+          resource: CAPI.RANCHER_CLUSTER,
+          product:  'manager',
+        },
+        query: { q: 'elemental' }
+      };
+
       [
         ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
         ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES,
@@ -131,7 +140,10 @@ export default {
           btnVisible:  true
         };
 
-        if (type === this.ELEMENTAL_CLUSTERS) {
+        if (type === this.ELEMENTAL_CLUSTERS && obj.count > 0) {
+          obj.btnRoute = clusterManageRoute;
+          obj.btnLabel = this.t(`elemental.dashboard.btnLabel.manage."${ type }"`);
+        } else {
           obj.btnRoute = clusterCreateRoute;
         }
 
@@ -179,7 +191,7 @@ export default {
   methods: {
     handleRoute(card) {
       if (!card.btnDisabled) {
-        this.$router.replace(card.btnRoute);
+        this.$router.push(card.btnRoute);
       }
     },
     async downloadMachineReg(item, btnCb) {
@@ -220,7 +232,7 @@ export default {
       <Banner
         class="mt-40"
         color="warning"
-        v-html="t('product.notInstalled', {}, true)"
+        v-html="t('product.notInstalledOrNoSchema', {}, true)"
       />
     </div>
     <div v-else>
@@ -228,7 +240,7 @@ export default {
         v-if="isElementalOpNotInstalledAndHasSchema"
         class="mb-20"
         color="warning"
-        v-html="t('product.notInstalled', {}, true)"
+        v-html="t('product.notInstalledHasSchema', {}, true)"
       />
       <h1 class="title">
         {{ t('elemental.menuLabels.titleDashboard') }}


### PR DESCRIPTION
Fixes #38 
Fixes #40 
Fixes #42 
Fixes #44 
Fixes #46 

- Add Banner component to `Registration Endpoints` "labels and annotations" section with explanatory information #38 
<img width="1951" alt="Screenshot 2022-11-16 at 09 59 20" src="https://user-images.githubusercontent.com/97888974/202211967-f5cd6a72-375a-4dca-b7fd-ff35eecef541.png">
<img width="1951" alt="Screenshot 2022-11-16 at 09 59 22" src="https://user-images.githubusercontent.com/97888974/202211975-5f94c527-3779-49ad-9b9f-146141b8d001.png">

- Update dashboard banner to reflect possible missing role for standard users (it's not possible to accurately capture this scenario due to RBAC constraints on several key CRDs such as `GlobalRoles`) #40 
<img width="2015" alt="Screenshot 2022-11-16 at 09 26 28" src="https://user-images.githubusercontent.com/97888974/202211572-fe100f4f-7f29-44ff-b3a2-71767ad10f00.png">

- Update dashboard cards so that "create elemental cluster" or "create registration endpoints" will become links to list views and with copy like "manage registration endpoints" or "manage elemental clusters" if count > 0 #42 
<img width="1951" alt="Screenshot 2022-11-16 at 14 49 06" src="https://user-images.githubusercontent.com/97888974/202212774-e267fd69-01c8-4e1b-875c-f554c0dd7d22.png">

- Update `machine count` on "create elemental cluster" so that the matching Inventory of Machines on "Inventory of Machines Selector Template" will be equal to the number of `machine count` #44 
<img width="1951" alt="Screenshot 2022-11-16 at 14 49 45" src="https://user-images.githubusercontent.com/97888974/202213210-c220a4c7-accb-48e5-905f-eea4a8cd2845.png">

- Update naming of CRDs for Elemental according to issue #46 