### PR TITLE
Fix advanced filter disappearing/changing

### DIFF
--- a/pkg/elemental/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/pkg/elemental/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -423,8 +423,7 @@ export default {
         if ( showRke2 ) {
           out.push({
             kind:  'group',
-            label: this.t('cluster.provider.k3s'),
-            badge: this.t('generic.techPreview')
+            label: this.t('cluster.provider.k3s')
           });
         }
 
@@ -2295,10 +2294,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .k3s-tech-preview-info {
-    color: var(--error);
-    padding-top: 10px;
-  }
   .patch-version {
     margin-top: 5px;
   }

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -7,7 +7,11 @@ import ResourceTable from '@shell/components/ResourceTable';
 import PercentageBar from '@shell/components/PercentageBar';
 import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
-import { ELEMENTAL_SCHEMA_IDS, ELEMENTAL_CLUSTER_PROVIDER } from '../config/elemental-types';
+import { 
+  ELEMENTAL_SCHEMA_IDS, 
+  ELEMENTAL_CLUSTER_PROVIDER,
+  KIND
+} from '../config/elemental-types';
 import { createElementalRoute } from '../utils/custom-routing';
 import { filterForElementalClusters } from '../utils/elemental-utils';
 
@@ -122,7 +126,7 @@ export default {
           resource: CAPI.RANCHER_CLUSTER,
           product:  'manager',
         },
-        query: { q: 'elemental' }
+        query: { q: KIND.MACHINE_INV_SELECTOR_TEMPLATES }
       };
 
       [

--- a/pkg/elemental/routing/elemental-routing.ts
+++ b/pkg/elemental/routing/elemental-routing.ts
@@ -1,4 +1,3 @@
-import { ELEMENTAL_PRODUCT_NAME } from '../config/elemental-types';
 import Dashboard from '../pages/index.vue';
 import ListElementalResource from '../pages/_resource/index.vue';
 import CreateElementalResource from '../pages/_resource/create.vue';
@@ -6,23 +5,23 @@ import ElementalResourceDetails from '../pages/_resource/_id.vue';
 
 const routes = [
   {
-    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster`,
-    path:      `/:product/c/:cluster/dashboard`,
+    name:      `c-cluster-product`,
+    path:      `/c/:cluster/:product/dashboard`,
     component: Dashboard,
   },
   {
-    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource`,
-    path:      `/:product/c/:cluster/:resource`,
+    name:      `c-cluster-product-resource`,
+    path:      `/c/:cluster/:product/:resource`,
     component: ListElementalResource,
   },
   {
-    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-create`,
-    path:      `/:product/c/:cluster/:resource/create`,
+    name:      `c-cluster-product-resource-create`,
+    path:      `/c/:cluster/:product/:resource/create`,
     component: CreateElementalResource,
   },
   {
-    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-id`,
-    path:      `/:product/c/:cluster/:resource/id`,
+    name:      `c-cluster-product-resource-id`,
+    path:      `/c/:cluster/:product/:resource/id`,
     component: ElementalResourceDetails,
   },
 ];

--- a/pkg/elemental/utils/custom-routing.ts
+++ b/pkg/elemental/utils/custom-routing.ts
@@ -3,7 +3,7 @@ import { ELEMENTAL_PRODUCT_NAME } from '../config/elemental-types';
 const BLANK_CLUSTER = '_';
 
 export const rootElementalRoute = () => ({
-  name:    `${ ELEMENTAL_PRODUCT_NAME }-c-cluster`,
+  name:    `c-cluster-product`,
   params: { product: ELEMENTAL_PRODUCT_NAME, cluster: BLANK_CLUSTER }
 });
 


### PR DESCRIPTION
Fixes #45 
Fixes #49

- fix issue related to routes where advanced filtering UI was disappearing/changing after YAML creation due to not conforming to routing convention #45 
- fix issue with tech preview label still appearing on cluster creation for K3s #49
- change query param for filtering elemental clusters

To test #45 :
- go to "Inventory of Machines"
- create an item via YAML
- after creation, make sure we still have the UI for advanced filtering

To test #49  :
- go to cluster creation and choose a k3s version. Make sure that the tech preview label doesn't appear anymore