### PR TITLE
fix path to chart config

### DIFF
--- a/charts/elemental/0.1.1/templates/cr.yaml
+++ b/charts/elemental/0.1.1/templates/cr.yaml
@@ -9,6 +9,6 @@ spec:
   plugin: # should initially follow the design of the Helm Chart.yaml fields, could discuss modifying this
     name: {{ include "plugin-server.fullname" . }}
     version: {{ (semver (default .Chart.AppVersion .Values.plugin.versionOverride)).Original }}
-    endpoint: https://raw.githubusercontent.com/aalves08/elemental-ui/main/extensions/elemental/0.1.1
+    endpoint: https://raw.githubusercontent.com/rancher/elemental-ui/main/extensions/elemental/0.1.1
     noCache: {{ .Values.plugin.noCache }}
 {{- end }}

--- a/charts/elemental/0.1.2/templates/cr.yaml
+++ b/charts/elemental/0.1.2/templates/cr.yaml
@@ -9,6 +9,6 @@ spec:
   plugin: # should initially follow the design of the Helm Chart.yaml fields, could discuss modifying this
     name: {{ include "plugin-server.fullname" . }}
     version: {{ (semver (default .Chart.AppVersion .Values.plugin.versionOverride)).Original }}
-    endpoint: https://raw.githubusercontent.com/aalves08/elemental-ui/publish-0.1.2/extensions/elemental/0.1.2
+    endpoint: https://raw.githubusercontent.com/rancher/elemental-ui/publish-0.1.2/extensions/elemental/0.1.2
     noCache: {{ .Values.plugin.noCache }}
 {{- end }}


### PR DESCRIPTION
- fix path to chart config to not come from a fork but from `rancher/elemental-ui` repo

FYI @richard-cox @nwmac going to merge this as it's a trivial change and build should come from the proper repo. 