### PR TITLE
fix routing issue that was prevent the correct display of the cluster explorer page

### DIFF
--- a/pkg/elemental/models/elemental-resource.js
+++ b/pkg/elemental/models/elemental-resource.js
@@ -9,11 +9,12 @@ export default class ElementalResource extends SteveModel {
   }
 
   get detailLocation() {
+    const schema = this.$getters['schemaFor'](this.type);
     const detailLocation = clone(this._detailLocation);
 
     detailLocation.params.resource = this.type;
 
-    if (detailLocation.name.includes('namespace')) {
+    if (schema?.attributes?.namespaced) {
       detailLocation.name = `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-namespace-id`;
     } else {
       detailLocation.name = `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-id`;

--- a/pkg/elemental/models/elemental-resource.js
+++ b/pkg/elemental/models/elemental-resource.js
@@ -5,4 +5,8 @@ export default class ElementalResource extends SteveModel {
   get listLocation() {
     return createElementalRoute('resource', { resource: this.type });
   }
+
+  get doneRoute() {
+    return this.listLocation.name;
+  }
 }

--- a/pkg/elemental/models/elemental-resource.js
+++ b/pkg/elemental/models/elemental-resource.js
@@ -1,9 +1,29 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
+import { clone } from '@shell/utils/object';
 import { createElementalRoute } from '../utils/custom-routing';
+import { ELEMENTAL_PRODUCT_NAME } from '../config/elemental-types';
 
 export default class ElementalResource extends SteveModel {
   get listLocation() {
     return createElementalRoute('resource', { resource: this.type });
+  }
+
+  get detailLocation() {
+    const detailLocation = clone(this._detailLocation);
+
+    detailLocation.params.resource = this.type;
+
+    if (detailLocation.name.includes('namespace')) {
+      detailLocation.name = `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-namespace-id`;
+    } else {
+      detailLocation.name = `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-id`;
+    }
+
+    return detailLocation;
+  }
+
+  get parentLocationOverride() {
+    return this.listLocation;
   }
 
   get doneRoute() {

--- a/pkg/elemental/routing/elemental-routing.ts
+++ b/pkg/elemental/routing/elemental-routing.ts
@@ -22,7 +22,12 @@ const routes = [
   },
   {
     name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-id`,
-    path:      `/:product/c/:cluster/:resource/id`,
+    path:      `/:product/c/:cluster/:resource/:id`,
+    component: ElementalResourceDetails,
+  },
+  {
+    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-namespace-id`,
+    path:      `/:product/c/:cluster/:resource/:namespace/:id`,
     component: ElementalResourceDetails,
   },
 ];

--- a/pkg/elemental/routing/elemental-routing.ts
+++ b/pkg/elemental/routing/elemental-routing.ts
@@ -1,3 +1,4 @@
+import { ELEMENTAL_PRODUCT_NAME } from '../config/elemental-types';
 import Dashboard from '../pages/index.vue';
 import ListElementalResource from '../pages/_resource/index.vue';
 import CreateElementalResource from '../pages/_resource/create.vue';
@@ -5,23 +6,23 @@ import ElementalResourceDetails from '../pages/_resource/_id.vue';
 
 const routes = [
   {
-    name:      `c-cluster-product`,
-    path:      `/c/:cluster/:product/dashboard`,
+    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster`,
+    path:      `/:product/c/:cluster/dashboard`,
     component: Dashboard,
   },
   {
-    name:      `c-cluster-product-resource`,
-    path:      `/c/:cluster/:product/:resource`,
+    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource`,
+    path:      `/:product/c/:cluster/:resource`,
     component: ListElementalResource,
   },
   {
-    name:      `c-cluster-product-resource-create`,
-    path:      `/c/:cluster/:product/:resource/create`,
+    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-create`,
+    path:      `/:product/c/:cluster/:resource/create`,
     component: CreateElementalResource,
   },
   {
-    name:      `c-cluster-product-resource-id`,
-    path:      `/c/:cluster/:product/:resource/id`,
+    name:      `${ ELEMENTAL_PRODUCT_NAME }-c-cluster-resource-id`,
+    path:      `/:product/c/:cluster/:resource/id`,
     component: ElementalResourceDetails,
   },
 ];

--- a/pkg/elemental/utils/custom-routing.ts
+++ b/pkg/elemental/utils/custom-routing.ts
@@ -3,7 +3,7 @@ import { ELEMENTAL_PRODUCT_NAME } from '../config/elemental-types';
 const BLANK_CLUSTER = '_';
 
 export const rootElementalRoute = () => ({
-  name:    `c-cluster-product`,
+  name:    `${ ELEMENTAL_PRODUCT_NAME }-c-cluster`,
   params: { product: ELEMENTAL_PRODUCT_NAME, cluster: BLANK_CLUSTER }
 });
 


### PR DESCRIPTION
Fixes #59 

- fix routing issue that was prevent the correct display of the cluster explorer page

**To test**
Go to OS management to load Elemental dashboard view
Go to your local Cluster on the side-menu (so that it loads the cluster explorer view)
Check that cluster explorer dashboard page is showing correctly and not displaying the Elemental dashboard page