### PR TITLE
fix switched up links for create and manage OS groups

### DIFF
--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -291,7 +291,10 @@ export default {
             <h3 class="mb-20">
               {{ machineRegTitle }}
             </h3>
-            <nuxt-link :to="machineRegListLocation">
+            <nuxt-link
+              :to="machineRegListLocation"
+              class="table-title-block-link"
+            >
               {{ t('elemental.dashboard.manageReg') }}
             </nuxt-link>
           </div>
@@ -334,7 +337,10 @@ export default {
             <h3 class="mb-20">
               {{ managedOsTitle }}
             </h3>
-            <nuxt-link :to="managedOsListLocation">
+            <nuxt-link
+              :to="managedOsListLocation"
+              class="table-title-block-link"
+            >
               {{ t('elemental.dashboard.manageOsImageUpgrade') }}
             </nuxt-link>
           </div>
@@ -475,6 +481,9 @@ export default {
     .table-title-block {
       display: flex;
       justify-content: space-between;
+    }
+    .table-title-block-link {
+      margin-top: 2px;
     }
 
     .token-truncate {

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -334,7 +334,7 @@ export default {
             <h3 class="mb-20">
               {{ managedOsTitle }}
             </h3>
-            <nuxt-link :to="managedOsCreateLocation">
+            <nuxt-link :to="managedOsListLocation">
               {{ t('elemental.dashboard.manageOsImageUpgrade') }}
             </nuxt-link>
           </div>
@@ -343,7 +343,7 @@ export default {
             class="empty-table-state"
           >
             <p>{{ t('elemental.dashboard.noManageOs') }}</p>
-            <nuxt-link :to="managedOsListLocation">
+            <nuxt-link :to="managedOsCreateLocation">
               {{ t('elemental.dashboard.noManageOsAction') }}
             </nuxt-link>
           </div>


### PR DESCRIPTION
Fixes #63 

- fix switched up links for create and manage OS groups part in `elemental-ui` dashboard view
- fix links vertical centering in `elemental-ui` dashboard view (check screenshot)

**Screenshots**
![Screenshot 2022-12-14 at 16 14 42](https://user-images.githubusercontent.com/97888974/207649791-0396a92e-9248-4006-a760-60429520e006.png)
![Screenshot 2022-12-16 at 14 26 38](https://user-images.githubusercontent.com/97888974/208120199-cb630d5c-85c5-4154-9e74-661bdd368999.png)


**To test**
- Install and run this repo (https://github.com/rancher/elemental-ui#readme)
**NOTE: If you already have the `elemental-ui` extension installed, you must uninstall it first otherwise the installed extension will superseed the local version!**

- Install `elemental-operator` in `local` cluster (got to `local` cluster -> open kube shell and run: https://elemental.docs.rancher.com/elementaloperatorchart-reference/#upgrading-chart)

- This will enable a side-menu entry called `OS management` (which will take you to the dashboard view of elemental)

- check that the links are correct on `OS management` dashboard view for the `Update Groups` (check screenshot)