### PR TITLE
add validation for inventory of machines labels

### DIFF
--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -42,8 +42,9 @@ export default {
   },
   data() {
     return {
-      cloudConfig:  typeof this.value.spec === 'string' ? this.value.spec : saferDump(this.value.spec),
-      yamlErrors:   null
+      cloudConfig: typeof this.value.spec === 'string' ? this.value.spec : saferDump(this.value.spec),
+      yamlErrors:  null,
+      isFormValid: true
     };
   },
   watch: {
@@ -96,6 +97,27 @@ export default {
         saveCb(false);
       }
     },
+    updateLabels(ev) {
+      this.value.setLabels(ev, 'machineInventoryLabels', true);
+      let labelLengthExceeded = false;
+
+      this.errors = [];
+
+      if (this.value.spec.machineInventoryLabels && Object.keys(this.value.spec.machineInventoryLabels).length) {
+        Object.keys(this.value.spec.machineInventoryLabels).forEach((key) => {
+          if (this.value.spec.machineInventoryLabels[key].length > 63) {
+            labelLengthExceeded = true;
+          }
+        });
+      }
+
+      if (labelLengthExceeded) {
+        this.isFormValid = false;
+        this.errors.push(this.t('elemental.machineRegistration.validation.machineInventoryLabels'));
+      } else {
+        this.isFormValid = true;
+      }
+    },
     onFileSelected(value) {
       const component = this.$refs.yamleditor;
 
@@ -116,6 +138,7 @@ export default {
     :mode="mode"
     :resource="value"
     :errors="errors"
+    :validation-passed="isFormValid"
     @error="e=>errors = e"
     @finish="save"
     @cancel="done"
@@ -186,7 +209,7 @@ export default {
                 :title="t('labels.labels.title')"
                 :read-allowed="false"
                 :value-can-be-empty="true"
-                @input="value.setLabels($event, 'machineInventoryLabels', true)"
+                @input="updateLabels($event)"
               />
             </div>
             <div class="row mb-10">

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -99,21 +99,55 @@ export default {
     },
     updateLabels(ev) {
       this.value.setLabels(ev, 'machineInventoryLabels', true);
+      let keyLengthExceeded = false;
+      let keyPrefixLengthExceeded = false;
+      let keyNameLengthExceeded = false;
       let labelLengthExceeded = false;
 
       this.errors = [];
 
       if (this.value.spec.machineInventoryLabels && Object.keys(this.value.spec.machineInventoryLabels).length) {
         Object.keys(this.value.spec.machineInventoryLabels).forEach((key) => {
+          // check length of "key" in key-value
+          if (key.includes('/')) {
+            const prefix = key.split('/')[0];
+            const name = key.split('/')[1];
+
+            if (prefix.length > 253) {
+              keyPrefixLengthExceeded = true;
+            }
+
+            if (name.length > 63) {
+              keyNameLengthExceeded = true;
+            }
+          } else if (key.length > 63) {
+            keyLengthExceeded = true;
+          }
+
+          // check length of "value" in key-value
           if (this.value.spec.machineInventoryLabels[key].length > 63) {
             labelLengthExceeded = true;
           }
         });
       }
 
-      if (labelLengthExceeded) {
-        this.isFormValid = false;
-        this.errors.push(this.t('elemental.machineRegistration.validation.machineInventoryLabels'));
+      if (labelLengthExceeded || keyLengthExceeded || keyPrefixLengthExceeded || keyNameLengthExceeded) {
+        if (labelLengthExceeded) {
+          this.isFormValid = false;
+          this.errors.push(this.t('elemental.machineRegistration.validation.machineInventoryLabelValueLength'));
+        }
+        if (keyLengthExceeded) {
+          this.isFormValid = false;
+          this.errors.push(this.t('elemental.machineRegistration.validation.machineInventoryLabelKeyLength'));
+        }
+        if (keyPrefixLengthExceeded) {
+          this.isFormValid = false;
+          this.errors.push(this.t('elemental.machineRegistration.validation.machineInventoryLabelKeyPrefixLength'));
+        }
+        if (keyNameLengthExceeded) {
+          this.isFormValid = false;
+          this.errors.push(this.t('elemental.machineRegistration.validation.machineInventoryLabelKeyNameLength'));
+        }
       } else {
         this.isFormValid = true;
       }

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -107,6 +107,8 @@ elemental:
         label: OS Image
         placeholder: Enter an OS image name
   machineRegistration:
+    validation:
+      machineInventoryLabels: One of the labels for Inventory of Machines exceeds the 63 characters limit. Please shorten the length of the label value
     edit:
       imageSetup: Setting up an OS image
       downloadMachineRegistrationFile: 'Download the Registration Endpoint file and follow the set of instructions on how to prepare your ISO image <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://rancher.github.io/elemental/quickstart/#preparing-the-iso">here</a>.'
@@ -118,8 +120,8 @@ elemental:
       configuration: Configuration
       cloudConfiguration: Cloud Configuration
       labelsAndAnnotations: Labels And Annotations
-      labelsAndAnnotationsMachInvBanner: 'Labels and annotations to be added to the <b>MachineInventory</b> when a new machine is registered. These can be used to select the correct MachineInventory when creating clusters and also can be used as templates using SMBIOS data. <br> For reference on SMBIOS data check the official <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://rancher.github.io/elemental/smbios">documentation</a>.'
-      labelsAndAnnotationsMachRegBanner: 'Labels and annotations for the <b>MachineRegistration</b> item about to be created/edited.'
+      labelsAndAnnotationsMachInvBanner: 'Labels and annotations to be added to the <b>Inventory of Machines</b> resource when a new machine is registered. These can be used to select the correct <b>Inventory of Machines</b> when creating clusters and also can be used as templates using SMBIOS data. <br> For reference on SMBIOS data check the official <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://rancher.github.io/elemental/smbios">documentation</a>.'
+      labelsAndAnnotationsMachRegBanner: 'Labels and annotations for the <b>Registration Endpoint</b> resource about to be created/edited.'
       readFromFile: Read from File
       name:
         label: Name

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -108,7 +108,10 @@ elemental:
         placeholder: Enter an OS image name
   machineRegistration:
     validation:
-      machineInventoryLabels: One of the labels for Inventory of Machines exceeds the 63 characters limit. Please shorten the length of the label value
+      machineInventoryLabelKeyLength: One of the labels for Inventory of Machines has a key that exceeds the 63 characters limit. Please shorten the length of the label key.
+      machineInventoryLabelKeyPrefixLength: One of the labels for Inventory of Machines has a key prefix that exceeds the 253 characters limit. Please shorten the length of the label key prefix.
+      machineInventoryLabelKeyNameLength: One of the labels for Inventory of Machines has a key name that exceeds the 63 characters limit. Please shorten the length of the label key name.
+      machineInventoryLabelValueLength: One of the labels for Inventory of Machines has a value that exceeds the 63 characters limit. Please shorten the length of the label value.
     edit:
       imageSetup: Setting up an OS image
       downloadMachineRegistrationFile: 'Download the Registration Endpoint file and follow the set of instructions on how to prepare your ISO image <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://rancher.github.io/elemental/quickstart/#preparing-the-iso">here</a>.'


### PR DESCRIPTION
Fixes #77 

- add validation for inventory of machines labels added when creating a registration endpoint

**Screenshots**
![Screenshot 2023-02-16 at 11 28 45](https://user-images.githubusercontent.com/97888974/219353520-c446be47-35ec-4b37-b56f-785f60d36ec7.png)

**To test**
- Go to `Elemental` -> `Registration Endpoint` -> Create
- Add a label for `Inventory of Machines` with it's value length greater than 63 chars
- Form should not be submittable 

Note: Did not use the `form-validation` mixin because I couldn't understand how it works and if it will work for this usecase