### PR TITLE
Improve OS groups

### DIFF
--- a/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
@@ -52,6 +52,9 @@ export default {
       // populate OS version selected
       if (this.value?.spec?.managedOSVersionName) {
         this.osVersionSelected = this.value?.spec?.managedOSVersionName;
+        this.useManagedOsImages = true;
+      } else {
+        this.useManagedOsImages = false;
       }
 
       // populate cluster targets selected

--- a/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
@@ -5,14 +5,22 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
+import { RadioGroup } from '@components/Form/Radio';
+import { allHash } from '@shell/utils/promise';
 import { _CREATE } from '@shell/config/query-params';
 import { CAPI } from '@shell/config/types';
-import { filterForElementalClusters } from '../utils/elemental-utils';
+import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
+import {
+  filterForElementalClusters,
+  filterForUsedElementalClustersOnManagedOs
+} from '../utils/elemental-utils';
+
+const STRING_SEPARATOR = '_***_';
 
 export default {
   name:       'ManagedOsImagesEditView',
   components: {
-    Loading, LabeledInput, LabeledSelect, CruResource, NameNsDescription
+    Loading, LabeledInput, LabeledSelect, CruResource, NameNsDescription, RadioGroup
   },
   mixins:     [CreateEditView],
   props:      {
@@ -26,21 +34,69 @@ export default {
     },
   },
   async fetch() {
-    const rancherClusters = await this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
+    const hash = {};
 
-    this.elementalClusters = filterForElementalClusters(rancherClusters);
+    hash.rancherClusters = this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
+    hash.osGroups = this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES });
+    hash.osVersions = this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSIONS });
+    hash.osVersionChannels = this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSION_CHANNELS });
+
+    const res = await allHash(hash);
+
+    this.elementalClusters = filterForElementalClusters(res.rancherClusters || []);
+    this.osGroups = res.osGroups || [];
+    this.osVersions = res.osVersions || [];
+    this.osVersionChannels = res.osVersionChannels || [];
   },
   data() {
-    return { elementalClusters: [], clusterTargets: this.handleClusterTargets() };
+    return {
+      elementalClusters:  [],
+      osGroups:           [],
+      osVersions:         [],
+      osVersionChannels:  [],
+      clusterTargets:     this.handleClusterTargets(),
+      useManagedOsImages: true,
+      osVersionSelected:  ''
+    };
   },
   computed: {
     clusterTargetOptions() {
-      return this.elementalClusters.map((cluster) => {
+      const targetableClusters = filterForUsedElementalClustersOnManagedOs(this.elementalClusters, this.osGroups);
+
+      return targetableClusters.map((cluster) => {
         return {
           label: cluster.name,
           value: cluster.name
         };
       });
+    },
+    managedOSVersionOptions() {
+      const out = [];
+
+      this.osVersionChannels.forEach((channel) => {
+        const versions = this.osVersions.filter((version) => {
+          const channelExists = version.metadata?.ownerReferences.find(ref => ref.name === channel.name);
+
+          return channelExists && Object.keys(channelExists).length;
+        });
+
+        if (versions.length) {
+          out.push({
+            kind:  'group',
+            label: this.t('elemental.osimage.create.managedOsImage.channel', { name: channel.name }),
+            value: this.t('elemental.osimage.create.managedOsImage.channel', { name: channel.name })
+          });
+
+          versions.forEach((v) => {
+            out.push({
+              label: v.name,
+              value: `${ channel.name }${ STRING_SEPARATOR }${ v.name }`
+            });
+          });
+        }
+      });
+
+      return out;
     },
     isCreate() {
       return this.mode === _CREATE;
@@ -68,6 +124,9 @@ export default {
       }
 
       return [];
+    },
+    handleManagedOSVersionNameChange(ev) {
+      this.value.spec.managedOSVersionName = ev.split(STRING_SEPARATOR)[1];
     }
   },
 };
@@ -97,19 +156,40 @@ export default {
         <h3>{{ t('elemental.osimage.create.spec') }}</h3>
         <LabeledSelect
           v-model="clusterTargets"
-          class="mb-40"
+          class="mb-20"
           :label="t('elemental.osimage.create.targetCluster.label')"
           :placeholder="t('elemental.osimage.create.targetCluster.placeholder', null, true)"
           :mode="mode"
           :options="clusterTargetOptions"
           :multiple="true"
         />
-        <LabeledInput
-          v-model.trim="value.spec.osImage"
-          :label="t('elemental.osimage.create.osImage.label')"
-          :placeholder="t('elemental.osimage.create.osImage.placeholder', null, true)"
+        <RadioGroup
+          v-model="useManagedOsImages"
+          class="mb-20"
+          name="os-image-mode"
+          :options="[true, false]"
+          :labels="[t('elemental.osimage.create.radioOptions.osImages'), t('elemental.osimage.create.radioOptions.registry')]"
           :mode="mode"
         />
+        <div v-if="useManagedOsImages">
+          <LabeledSelect
+            v-model="osVersionSelected"
+            :mode="mode"
+            :options="managedOSVersionOptions"
+            label-key="elemental.osimage.create.managedOsImage.label"
+            :placeholder="t('elemental.osimage.create.managedOsImage.placeholder', null, true)"
+            option-key="value"
+            @input="handleManagedOSVersionNameChange($event)"
+          />
+        </div>
+        <div v-else>
+          <LabeledInput
+            v-model.trim="value.spec.osImage"
+            :label="t('elemental.osimage.create.osImage.label')"
+            :placeholder="t('elemental.osimage.create.osImage.placeholder', null, true)"
+            :mode="mode"
+          />
+        </div>
       </div>
     </div>
   </CruResource>

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -99,18 +99,9 @@ export function init($plugin, store) {
     {
       name:          'TargetClusters',
       labelKey:      'tableHeaders.targetClusters',
-      getValue:      (row) => {
-        let val = '';
-
-        row.spec?.clusterTargets?.forEach((target, i) => {
-          val += target.clusterName;
-          if (i !== row.spec?.clusterTargets?.length - 1) {
-            val += ', ';
-          }
-        });
-
-        return val || '---';
-      },
+      value:         'clusterTargetsList',
+      getValue:      row => row.clusterTargetsList || '---',
+      sort:          ['clusterTargetsList']
     },
     AGE
   ]);

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -79,8 +79,42 @@ export function init($plugin, store) {
     canYaml:     true,
     customRoute: createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES })
   });
+  headers(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES, [
+    STATE,
+    NAME_COL,
+    {
+      name:          'OsImagePath',
+      labelKey:      'tableHeaders.imagePath',
+      value:         'spec.osImage',
+      getValue:      row => row.spec.osImage || '---',
+      sort:          ['spec.osImage']
+    },
+    {
+      name:          'OsVersion',
+      labelKey:      'tableHeaders.osVersion',
+      value:         'spec.managedOSVersionName',
+      getValue:      row => row.spec.managedOSVersionName || '---',
+      sort:          ['spec.managedOSVersionName']
+    },
+    {
+      name:          'TargetClusters',
+      labelKey:      'tableHeaders.targetClusters',
+      getValue:      (row) => {
+        let val = '';
 
-  // advanced tab
+        row.spec?.clusterTargets?.forEach((target, i) => {
+          val += target.clusterName;
+          if (i !== row.spec?.clusterTargets?.length - 1) {
+            val += ', ';
+          }
+        });
+
+        return val || '---';
+      },
+    },
+    AGE
+  ]);
+
   weightType(ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR, 10, true);
   configureType(ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR, {
     isCreatable: true,
@@ -99,6 +133,7 @@ export function init($plugin, store) {
     customRoute: createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR_TEMPLATES })
   });
 
+  // advanced tab
   weightType(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSIONS, 8, true);
   configureType(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSIONS, {
     isCreatable: true,
@@ -106,6 +141,17 @@ export function init($plugin, store) {
     isRemovable: true,
     customRoute: createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSIONS })
   });
+  headers(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSIONS, [
+    STATE,
+    NAME_COL,
+    {
+      name:          'OsVersionChannels',
+      labelKey:      'tableHeaders.osVersionChannel',
+      getValue:      row => row.metadata?.ownerReferences?.[0]?.name || '---',
+      sort:          ['metadata.ownerReferences.[0].name']
+    },
+    AGE
+  ]);
 
   weightType(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSION_CHANNELS, 7, true);
   configureType(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSION_CHANNELS, {
@@ -114,6 +160,17 @@ export function init($plugin, store) {
     isRemovable: true,
     customRoute: createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSION_CHANNELS })
   });
+  headers(ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSION_CHANNELS, [
+    STATE,
+    NAME_COL,
+    {
+      name:          'ChannelImage',
+      labelKey:      'tableHeaders.channelImage',
+      getValue:      row => row.spec?.options?.image || '---',
+      sort:          ['spec.options.image']
+    },
+    AGE
+  ]);
 
   basicType([
     ELEMENTAL_TYPES.DASHBOARD,

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -13,6 +13,11 @@ tableHeaders:
   token: Token
   downloadTableDashboard: ''
   download: 'Download'
+  imagePath: Image Path
+  osVersion: OS Version
+  osVersionChannel: OS Version Channel
+  channelImage: Channel Image
+  targetClusters: Target Clusters
 
 typeLabel:
   elemental:  |-
@@ -103,9 +108,16 @@ elemental:
       targetCluster:
         label: Target Cluster
         placeholder: Enter a target cluster name
+      radioOptions:
+        osImages: Use Managed OS version
+        registry: Use image from registry
       osImage:
-        label: OS Image
-        placeholder: Enter an OS image name
+        label: Image path
+        placeholder: Enter an OS image path
+      managedOsImage:
+        label: Managed OS version
+        placeholder: Select a Managed OS version
+        channel: OS Channel - { name }
   machineRegistration:
     edit:
       imageSetup: Setting up an OS image

--- a/pkg/elemental/models/elemental.cattle.io.managedosimage.js
+++ b/pkg/elemental/models/elemental.cattle.io.managedosimage.js
@@ -12,4 +12,21 @@ export default class ManagedOsImage extends ElementalResource {
       Vue.set(this, 'metadata', { namespace: ELEMENTAL_DEFAULT_NAMESPACE });
     }
   }
+
+  get clusterTargetsList() {
+    if (this.spec?.clusterTargets?.length) {
+      let val = '';
+
+      this.spec.clusterTargets.forEach((target, i) => {
+        val += target.clusterName;
+        if (i !== this.spec.clusterTargets.length - 1) {
+          val += ', ';
+        }
+      });
+
+      return val || '---';
+    }
+
+    return '---';
+  }
 }

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -95,12 +95,19 @@ export default {
       managedOsHeaders:  [
         NAME,
         {
-          name:     'osImage',
-          labelKey: 'tableHeaders.osImage',
-          value:    'spec.osImage',
-          getValue: row => row.spec?.osImage,
-          sort:     'spec.osImage'
-        }
+          name:          'OsVersion',
+          labelKey:      'tableHeaders.osVersion',
+          value:         'spec.managedOSVersionName',
+          getValue:      row => row.spec.managedOSVersionName || '---',
+          sort:          ['spec.managedOSVersionName']
+        },
+        {
+          name:          'TargetClusters',
+          labelKey:      'tableHeaders.targetClusters',
+          value:         'clusterTargetsList',
+          getValue:      row => row.clusterTargetsList || '---',
+          sort:          ['clusterTargetsList']
+        },
       ],
       colorStops: {
         0: '--error', 20: '--warning', 75: '--info', 95: '--success'

--- a/pkg/elemental/utils/elemental-utils.js
+++ b/pkg/elemental/utils/elemental-utils.js
@@ -4,3 +4,19 @@ export function filterForElementalClusters(clusters) {
   return clusters.filter(cluster => cluster.spec?.rkeConfig?.machinePools?.length &&
   cluster.spec?.rkeConfig?.machinePools[0].machineConfigRef.kind === KIND.MACHINE_INV_SELECTOR_TEMPLATES);
 }
+
+export function filterForUsedElementalClustersOnManagedOs(elementalClusters, osGroups) {
+  const out = [...elementalClusters];
+
+  osGroups.forEach((group) => {
+    group.spec?.clusterTargets?.forEach((target) => {
+      if (elementalClusters.find(c => c.name === target.clusterName)) {
+        const index = out.findIndex(c => c.name === target.clusterName);
+
+        out.splice(index, 1);
+      }
+    });
+  });
+
+  return out;
+}


### PR DESCRIPTION
Fixes #3 

- add table headers to multiple elemental resources (`Update Groups`, `OS Versions`, `OS Version Channels`)
- add `LabeledSelect` to `create` page for `Update Groups` form in order to select `OS versions` 
- add logic to prevent using `target clusters` that have already been used on `Update Groups`

### How to test
- Go to `Cluster Management` -> `Create` -> Create a couple of elemental clusters (next to the Custom type)
- Go to `Elemental` -> `OS Version Channel` -> `Create from YAML`
- Use this YAML to create an `OS Version Channel`:
```
apiVersion: elemental.cattle.io/v1beta1
kind: ManagedOSVersionChannel
metadata:
  name: elemental-test-channel
  namespace: fleet-default
spec:
  options:
    image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
  type: custom
```
**Note: The `OS Versions` will be created automatically after a minute or so**
_(based on https://github.com/rancher/elemental/issues/649#issuecomment-1422873628)_

- After making sure you have the `OS Versions`, go to `Elemental` -> `Update Groups` -> `Create`
- Make sure the `Managed OS Version` select is correctly populated with the list of `OS versions` per `OS Version Channels`
and that you can successfully create an `Update Group` with a `Managed OS Version`
- Make sure that when creating an `Update Group`, you can only target Elemental clusters that haven't already been targeted in another `Update Group`.
- Check new table headers for `Update Groups`, `OS Versions`, `OS Version Channels`


### Screenshots
![Screenshot 2023-02-20 at 16 28 04](https://user-images.githubusercontent.com/97888974/220165757-1686b7e8-1600-46a9-bbb7-c22c6bb64244.png)
![Screenshot 2023-02-20 at 16 28 07](https://user-images.githubusercontent.com/97888974/220165765-5e302611-83ec-421f-8d57-66f974bbaaf3.png)
![Screenshot 2023-02-20 at 16 28 09](https://user-images.githubusercontent.com/97888974/220165766-d18083e2-4224-4a01-8588-d863ca5361f0.png)
![Screenshot 2023-02-20 at 16 49 26](https://user-images.githubusercontent.com/97888974/220165771-e334c96a-3562-44ea-a5da-67a01fe4b13a.png)
![Screenshot 2023-02-21 at 16 24 34](https://user-images.githubusercontent.com/97888974/220402248-3aeb945d-55b7-4023-9a1d-a65ead9235fa.png)
