### PR TITLE
create UI for OS version channels

### DIFF
--- a/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
@@ -1,0 +1,64 @@
+<script>
+import Loading from '@shell/components/Loading.vue';
+import CruResource from '@shell/components/CruResource.vue';
+import CreateEditView from '@shell/mixins/create-edit-view';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import NameNsDescription from '@shell/components/form/NameNsDescription';
+
+export default {
+  name:       'ManagedOsVersionChannelEditView',
+  components: {
+    Loading, LabeledInput, CruResource, NameNsDescription
+  },
+  mixins:     [CreateEditView],
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    },
+  },
+  async fetch() {},
+  data() {
+    return {};
+  },
+  computed: {},
+  methods:  {},
+};
+</script>
+
+<template>
+  <Loading v-if="!value" />
+  <CruResource
+    v-else
+    :done-route="doneRoute"
+    :can-yaml="true"
+    :mode="mode"
+    :resource="value"
+    :errors="errors"
+    @error="e=>errors = e"
+    @finish="save"
+    @cancel="done"
+  >
+    <div class="row mt-40 mb-20">
+      <div class="col span-12 mb-20">
+        <h3>{{ t('elemental.osversionchannels.create.configuration') }}</h3>
+        <NameNsDescription v-model="value" :mode="mode" :description-hidden="true" :namespaced="false" />
+      </div>
+    </div>
+    <div v-if="value.spec" class="row mb-20">
+      <div class="col span-6 mb-20">
+        <h3>{{ t('elemental.osversionchannels.create.spec') }}</h3>
+        <LabeledInput
+          v-model.trim="value.spec.options.image"
+          :label="t('elemental.osversionchannels.create.imageRegistry.label')"
+          :placeholder="t('elemental.osversionchannels.create.imageRegistry.placeholder', null, true)"
+          :mode="mode"
+        />
+      </div>
+    </div>
+  </CruResource>
+</template>

--- a/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
@@ -19,14 +19,8 @@ export default {
     mode: {
       type:     String,
       required: true
-    },
-  },
-  async fetch() {},
-  data() {
-    return {};
-  },
-  computed: {},
-  methods:  {},
+    }
+  }
 };
 </script>
 
@@ -54,8 +48,8 @@ export default {
         <h3>{{ t('elemental.osversionchannels.create.spec') }}</h3>
         <LabeledInput
           v-model.trim="value.spec.options.image"
-          :label="t('elemental.osversionchannels.create.imageRegistry.label')"
-          :placeholder="t('elemental.osversionchannels.create.imageRegistry.placeholder', null, true)"
+          :label="t('elemental.osversionchannels.create.registryUri.label')"
+          :placeholder="t('elemental.osversionchannels.create.registryUri.placeholder', null, true)"
           :mode="mode"
         />
       </div>

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -161,6 +161,6 @@ elemental:
     create:
       configuration: Configuration
       spec: Spec
-      imageRegistry:
+      registryUri:
         label: Image registry path
         placeholder: Enter an image registry path

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -157,3 +157,10 @@ elemental:
     createCluster: Create Elemental Cluster
     import: YAML import
     updateForCreateClusterError: Error updating Inventory of Machines with label for creating a cluster
+  osversionchannels:
+    create:
+      configuration: Configuration
+      spec: Spec
+      imageRegistry:
+        label: Image registry path
+        placeholder: Enter an image registry path

--- a/pkg/elemental/models/elemental.cattle.io.managedosversionchannel.js
+++ b/pkg/elemental/models/elemental.cattle.io.managedosversionchannel.js
@@ -1,0 +1,15 @@
+import Vue from 'vue';
+import { _CREATE } from '@shell/config/query-params';
+import { ELEMENTAL_DEFAULT_NAMESPACE } from '../types';
+import ElementalResource from './elemental-resource';
+
+export default class ManagedOsVersionChannel extends ElementalResource {
+  applyDefaults(vm, mode) {
+    if ( !this.spec ) {
+      Vue.set(this, 'spec', { options: { image: '' } });
+    }
+    if ( !this.metadata || mode === _CREATE ) {
+      Vue.set(this, 'metadata', { namespace: ELEMENTAL_DEFAULT_NAMESPACE });
+    }
+  }
+}

--- a/pkg/elemental/models/elemental.cattle.io.managedosversionchannel.js
+++ b/pkg/elemental/models/elemental.cattle.io.managedosversionchannel.js
@@ -6,7 +6,7 @@ import ElementalResource from './elemental-resource';
 export default class ManagedOsVersionChannel extends ElementalResource {
   applyDefaults(vm, mode) {
     if ( !this.spec ) {
-      Vue.set(this, 'spec', { options: { image: '' } });
+      Vue.set(this, 'spec', { options: { image: '' }, type: 'custom' });
     }
     if ( !this.metadata || mode === _CREATE ) {
       Vue.set(this, 'metadata', { namespace: ELEMENTAL_DEFAULT_NAMESPACE });


### PR DESCRIPTION
Fixes #81 

- create UI for `OS version channels`

### Test
- Go to `Elemental` -> `OS versions` and delete them all if you have them on the list
- Go to `Elemental` -> `OS versions channels` and delete them all if you have them on the list
- Go to `Elemental` -> `OS versions channels` -> `Create` and create a new channel with the following image path:
`registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest`

Wait a minute or so and confirm that new `OS versions` have appeared from the registry you entered

- Go to `Elemental` -> `OS versions channels` -> `Edit YAML` the OS version channel created
- Make sure it has the following properties (`name` can change):
```
apiVersion: elemental.cattle.io/v1beta1
kind: ManagedOSVersionChannel
metadata:
  name: elemental-test-channel
  namespace: fleet-default
spec:
  options:
    image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
  type: custom
```

### Screenshots
![Screenshot 2023-02-22 at 09 26 25](https://user-images.githubusercontent.com/97888974/220578656-46ee19aa-0c8f-4b0e-8d51-8985b23611f9.png)
