### PR TITLE
Add data-testid attributes to help QA

### DIFF
--- a/pkg/elemental/detail/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/detail/elemental.cattle.io.machineregistration.vue
@@ -103,6 +103,7 @@ export default {
         <h3>{{ t('elemental.machineRegistration.create.registrationURL.title') }}</h3>
         <DetailText
           v-show="registrationUrl"
+          data-testid="registration-url"
           :value="registrationUrl"
           :label="t('elemental.machineRegistration.create.registrationURL.label')"
         />
@@ -114,7 +115,7 @@ export default {
       <div class="col span-12">
         <h3>{{ t('elemental.machineRegistration.edit.imageSetup') }}</h3>
         <p v-html="t('elemental.machineRegistration.edit.downloadMachineRegistrationFile', {}, true)" />
-        <AsyncButton class="mt-10" mode="download" @click="download" />
+        <AsyncButton class="mt-10" mode="download" data-testid="download-btn" @click="download" />
       </div>
     </div>
     <div class="row mb-20">

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -206,6 +206,7 @@ export default {
         >
           <FileSelector
             class="btn role-secondary"
+            data-testid="read-from-file-btn"
             :label="t('elemental.machineRegistration.create.readFromFile')"
             @selected="onFileSelected"
           />
@@ -223,20 +224,23 @@ export default {
         <h3 class="mt-10">
           {{ t('elemental.machineRegistration.create.labelsAndAnnotations') }}
         </h3>
-        <Tabbed>
+        <Tabbed data-testid="labels-and-annotations-block">
           <Tab
             label-key="elemental.machineRegistration.create.machineInv"
             name="machine-inventory"
+            data-testid="mach-inv-tab"
             :weight="3"
           >
             <Banner
               class="mb-40"
               color="info"
+              data-testid="mach-inv-banner"
               v-html="t('elemental.machineRegistration.create.labelsAndAnnotationsMachInvBanner', {}, true)"
             />
             <div class="row mb-30">
               <KeyValue
                 key="labels"
+                data-testid="add-label-mach-inv"
                 :value="value.machineInventoryLabels"
                 :add-label="t('labels.addLabel')"
                 :mode="mode"
@@ -249,6 +253,7 @@ export default {
             <div class="row mb-10">
               <KeyValue
                 key="annotations"
+                data-testid="add-annotation-mach-inv"
                 :value="value.machineInventoryAnnotations"
                 :add-label="t('labels.addAnnotation')"
                 :mode="mode"
@@ -262,16 +267,19 @@ export default {
           <Tab
             label-key="elemental.machineRegistration.create.machineReg"
             name="machine-reg"
+            data-testid="mach-reg-tab"
             :weight="2"
           >
             <Banner
               class="mb-40"
               color="info"
+              data-testid="mach-reg-banner"
               v-html="t('elemental.machineRegistration.create.labelsAndAnnotationsMachRegBanner', {}, true)"
             />
             <div class="row mb-30">
               <KeyValue
                 key="labels"
+                data-testid="add-label-mach-reg"
                 :value="value.labels"
                 :add-label="t('labels.addLabel')"
                 :mode="mode"
@@ -284,6 +292,7 @@ export default {
             <div class="row mb-10">
               <KeyValue
                 key="annotations"
+                data-testid="add-annotation-mach-reg"
                 :value="value.annotations"
                 :add-label="t('labels.addAnnotation')"
                 :mode="mode"

--- a/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
@@ -162,6 +162,7 @@ export default {
         <LabeledSelect
           v-model="clusterTargets"
           class="mb-20"
+          data-testid="cluster-target"
           :label="t('elemental.osimage.create.targetCluster.label')"
           :placeholder="t('elemental.osimage.create.targetCluster.placeholder', null, true)"
           :mode="mode"
@@ -172,6 +173,7 @@ export default {
         <RadioGroup
           v-model="useManagedOsImages"
           class="mb-20"
+          data-testid="upgrade-choice-selector"
           name="os-image-mode"
           :options="[true, false]"
           :labels="[t('elemental.osimage.create.radioOptions.osImages'), t('elemental.osimage.create.radioOptions.registry')]"
@@ -180,6 +182,7 @@ export default {
         <div v-if="useManagedOsImages">
           <LabeledSelect
             v-model="osVersionSelected"
+            data-testid="os-version-box"
             :mode="mode"
             :options="managedOSVersionOptions"
             label-key="elemental.osimage.create.managedOsImage.label"
@@ -191,6 +194,7 @@ export default {
         <div v-else>
           <LabeledInput
             v-model.trim="value.spec.osImage"
+            data-testid="os-image-box"
             :label="t('elemental.osimage.create.osImage.label')"
             :placeholder="t('elemental.osimage.create.osImage.placeholder', null, true)"
             :mode="mode"

--- a/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
@@ -48,6 +48,7 @@ export default {
         <h3>{{ t('elemental.osversionchannels.create.spec') }}</h3>
         <LabeledInput
           v-model.trim="value.spec.options.image"
+          data-testid="os-version-channel-path"
           :label="t('elemental.osversionchannels.create.registryUri.label')"
           :placeholder="t('elemental.osversionchannels.create.registryUri.placeholder', null, true)"
           :mode="mode"

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -218,6 +218,13 @@ export default {
 
         btnCb(false);
       }
+    },
+    formatDataTestid(item) {
+      try {
+        return item.toLowerCase().replace(/\s/g, '-');
+      } catch (error) {
+        return 'name-not-generated';
+      }
     }
   },
 };
@@ -235,6 +242,7 @@ export default {
         <img
           src="../icon-v2.svg"
           height="64"
+          data-testid="elemental-icon"
         />
       </div>
       <h1 class="mb-20">
@@ -242,11 +250,13 @@ export default {
       </h1>
       <p
         class="description"
+        data-testid="elemental-description-text"
         v-html="t('product.description', {}, true)"
       />
       <Banner
         class="mt-40"
         color="warning"
+        data-testid="warning-not-install-or-no-schema"
         v-html="t('product.notInstalledOrNoSchema', {}, true)"
       />
     </div>
@@ -255,9 +265,10 @@ export default {
         v-if="isElementalOpNotInstalledAndHasSchema"
         class="mb-20"
         color="warning"
+        data-testid="warning-not-install-with-schema"
         v-html="t('product.notInstalledHasSchema', {}, true)"
       />
-      <h1 class="title">
+      <h1 class="title" data-testid="elemental-main-title">
         {{ t('elemental.menuLabels.titleDashboard') }}
       </h1>
       <!-- Top cards -->
@@ -265,6 +276,7 @@ export default {
         <div
           v-for="card, index in cards"
           :key="index"
+          :data-testid="`card-${formatDataTestid(card.title)}`"
           class="card"
         >
           <div class="card-top-block">
@@ -275,6 +287,7 @@ export default {
             v-if="card.type !== machineInvCrd || (card.type === machineInvCrd && !card.count)"
             type="button"
             class="btn role-secondary"
+            :data-testid="`button-${formatDataTestid(card.btnLabel)}`"
             :class="{disabled: card.btnDisabled}"
             @click="handleRoute(card)"
           >
@@ -298,7 +311,10 @@ export default {
       </div>
       <!-- Tables -->
       <div class="main-tables-container mb-40 mt-40">
-        <div class="table-list">
+        <div
+          class="table-list"
+          data-testid="machine-reg-block"
+        >
           <div class="table-title-block">
             <h3 class="mb-20">
               {{ machineRegTitle }}
@@ -306,6 +322,7 @@ export default {
             <nuxt-link
               :to="machineRegListLocation"
               class="table-title-block-link"
+              data-testid="manage-reg-btn"
             >
               {{ t('elemental.dashboard.manageReg') }}
             </nuxt-link>
@@ -315,7 +332,10 @@ export default {
             class="empty-table-state"
           >
             <p>{{ t('elemental.dashboard.noMachineReg') }}</p>
-            <nuxt-link :to="machineRegCreateLocation">
+            <nuxt-link
+              :to="machineRegCreateLocation"
+              data-testid="create-machine-reg-btn"
+            >
               {{ t('elemental.dashboard.noMachineRegAction') }}
             </nuxt-link>
           </div>
@@ -344,7 +364,10 @@ export default {
             </template>
           </ResourceTable>
         </div>
-        <div class="table-list">
+        <div
+          class="table-list"
+          data-testid="update-group-block"
+        >
           <div class="table-title-block">
             <h3 class="mb-20">
               {{ managedOsTitle }}
@@ -352,6 +375,7 @@ export default {
             <nuxt-link
               :to="managedOsListLocation"
               class="table-title-block-link"
+              data-testid="manage-update-group-btn"
             >
               {{ t('elemental.dashboard.manageOsImageUpgrade') }}
             </nuxt-link>
@@ -361,7 +385,10 @@ export default {
             class="empty-table-state"
           >
             <p>{{ t('elemental.dashboard.noManageOs') }}</p>
-            <nuxt-link :to="managedOsCreateLocation">
+            <nuxt-link
+              :to="managedOsCreateLocation"
+              data-testid="create-update-group-btn"
+            >
               {{ t('elemental.dashboard.noManageOsAction') }}
             </nuxt-link>
           </div>


### PR DESCRIPTION
Fix https://github.com/rancher/elemental/issues/709

I updated my Cypress code to test and use the new attributes having built the dashboard locally.

For instance I can replace ugly Cypress code like this:
```
cy.get(':nth-child(4) > .labeled-select')
  .contains('Managed OS version')
  .click();
```
by
```
cy.get('[data-testid="os-version-box"]')
  .parents()
  .contains('staging')
  .click();
```