### PR TITLE
OS version-based updates

### DIFF
--- a/pkg/elemental/components/BuildIso.vue
+++ b/pkg/elemental/components/BuildIso.vue
@@ -28,17 +28,19 @@ export default {
   },
   async fetch() {
     this.seedImagesList = await this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.SEED_IMAGE });
+    const managedOsVersions = await this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSIONS });
+
+    this.filteredManagedOsVersions = managedOsVersions.filter(v => v.spec?.type === 'iso') || [];
+
+    if (this.filteredManagedOsVersions.length) {
+      this.buildIsoOsVersionSelected = this.filteredManagedOsVersions[0].spec?.metadata?.uri;
+    }
   },
   data() {
     return {
-      seedImagesList:     [],
-      buildIsoOsVersions: [
-        {
-          label: 'Elemental Teal x86 64bit - 1.1.4',
-          value: 'https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64-1.1.4-Build9.6.iso?PEDANTIC=1'
-        }
-      ],
-      buildIsoOsVersionSelected:    'https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64-1.1.4-Build9.6.iso?PEDANTIC=1',
+      seedImagesList:               [],
+      filteredManagedOsVersions:    [],
+      buildIsoOsVersionSelected:    '',
       registrationEndpointSelected: '',
       isoBuildTriggerError:         '',
       seedImage:                    undefined,
@@ -46,6 +48,14 @@ export default {
     };
   },
   computed: {
+    buildIsoOsVersions() {
+      return this.filteredManagedOsVersions.map((f) => {
+        return {
+          label: f.spec?.metadata?.displayName,
+          value: f.spec?.metadata?.uri,
+        };
+      });
+    },
     registrationEndpointsOptions() {
       const activeRegEndpoints = this.registrationEndpointList.filter(item => item.state === 'active');
 

--- a/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
@@ -99,7 +99,7 @@ export default {
           // use only the same namespace as the OS groups for now...
           const channelExists = version.metadata?.ownerReferences.find(ref => ref.name === channel.name && this.value?.metadata?.namespace === channel.metadata?.namespace);
 
-          return channelExists && Object.keys(channelExists).length && this.value?.metadata?.namespace === version.metadata?.namespace;
+          return channelExists && Object.keys(channelExists).length && this.value?.metadata?.namespace === version.metadata?.namespace && version.spec?.type === 'container';
         });
 
         if (versions.length) {

--- a/pkg/elemental/list/elemental.cattle.io.managedosversion.vue
+++ b/pkg/elemental/list/elemental.cattle.io.managedosversion.vue
@@ -1,0 +1,40 @@
+<script>
+import ResourceTable from '@shell/components/ResourceTable';
+export default {
+  name:       'ListManagedOsVersion',
+  components: { ResourceTable },
+  props:      {
+    resource: {
+      type:     String,
+      required: true,
+    },
+    schema: {
+      type:     Object,
+      required: true,
+    },
+    rows: {
+      type:     Array,
+      required: true,
+    },
+    loading: {
+      type:     Boolean,
+      required: false,
+    },
+  },
+  computed: {
+    parsedRows() {
+      return this.rows.filter(r => r.spec?.type === 'container');
+    }
+  },
+};
+</script>
+
+<template>
+  <div>
+    <ResourceTable
+      :schema="schema"
+      :rows="parsedRows"
+      :loading="loading"
+    />
+  </div>
+</template>


### PR DESCRIPTION
Based on the work done by the backend here https://github.com/rancher/elemental-operator/pull/435#issuecomment-1527735059, where we have now included in the OS Versions two different types `container` and `iso`, there are a few adjustments to be done on the UI side:

Fixes #104 
- Instead of showing all the channels, show only the one's with type `container` for upgrading an OS (changes to `edit/elemental.cattle.io.managedosimage.vue`)

Fixes #105 
- Update `BuildIso` component to get a list of official iso's from OS versions instead of having an hardcoded image

Fixes #106
- Create custom list view for OS versions to show only type `container` as it was meant to