### PR TITLE
Concatenate display label with version on Select for ISO's on build ISO feature

### DIFF
--- a/pkg/elemental/components/BuildIso.vue
+++ b/pkg/elemental/components/BuildIso.vue
@@ -51,7 +51,7 @@ export default {
     buildIsoOsVersions() {
       return this.filteredManagedOsVersions.map((f) => {
         return {
-          label: f.spec?.metadata?.displayName,
+          label: `${ f.spec?.metadata?.displayName } ${ f.spec?.version }`,
           value: f.spec?.metadata?.uri,
         };
       });


### PR DESCRIPTION
Fixes #123 

- adds label concatenation between `displayName` and `version` fields to make label unique to the user

![Screenshot 2023-06-15 at 17 34 55](https://github.com/rancher/elemental-ui/assets/97888974/bb037065-ca79-45af-8c90-db5683879cf7)
