### PR TITLE
Install elemental-operator from Rancher Markeplace chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@rancher/components": "0.1.0-alpha.9",
-    "@rancher/shell": "0.3.26",
+    "@rancher/shell": "0.3.27",
     "@types/lodash": "4.14.184",
     "core-js": "3.21.1",
     "css-loader": "4.3.0"

--- a/pkg/elemental/components/BuildIso.vue
+++ b/pkg/elemental/components/BuildIso.vue
@@ -210,9 +210,9 @@ export default {
     </div>
     <Banner
       v-if="isoBuildTriggerError || isoBuildProcessError"
+      v-clean-html="isoBuildTriggerError || isoBuildProcessError"
       color="error"
       data-testid="build-iso-banner"
-      v-html="isoBuildTriggerError || isoBuildProcessError"
     />
   </div>
 </template>

--- a/pkg/elemental/components/DashboardView.vue
+++ b/pkg/elemental/components/DashboardView.vue
@@ -1,0 +1,531 @@
+<script>
+import { allHash } from '@shell/utils/promise';
+import { CAPI, CATALOG } from '@shell/config/types';
+import { NAME } from '@shell/config/table-headers';
+import ResourceTable from '@shell/components/ResourceTable';
+import PercentageBar from '@shell/components/PercentageBar';
+import { Banner } from '@components/Banner';
+import {
+  ELEMENTAL_SCHEMA_IDS,
+  ELEMENTAL_CLUSTER_PROVIDER,
+  KIND
+} from '../config/elemental-types';
+import { createElementalRoute } from '../utils/custom-routing';
+import { filterForElementalClusters } from '../utils/elemental-utils';
+import BuildIso from './BuildIso';
+
+const MAX_ITEMS_PER_TABLE = 6;
+
+export default {
+  name:       'DashboardView',
+  components: {
+    Banner,
+    PercentageBar,
+    ResourceTable,
+    BuildIso,
+  },
+  async fetch() {
+    const requests = {
+      // needed for table
+      machineRegistrations: this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
+      // needed for resource gauge
+      machineInventories:   this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES }),
+      rancherClusters:      this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
+      // needed for table
+      managedOsImages:      this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
+      // needed to populate cluster name col on machine inventories list
+      machineInvSelector:   this.$store.dispatch(`management/findAll`, { type: ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR }),
+      elementalSchema:      this.$store.getters['management/schemaFor'](ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES)
+    };
+
+    // needed to check if operator is installed
+    if (this.$store.getters['management/canList'](CATALOG.APP)) {
+      requests.installedApps = this.$store.dispatch('management/findAll', { type: CATALOG.APP });
+    }
+
+    const allDispatches = await allHash(requests);
+
+    this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS] = allDispatches.machineRegistrations;
+    this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES] = allDispatches.machineInventories;
+    this.resourcesData[this.ELEMENTAL_CLUSTERS] = filterForElementalClusters(allDispatches.rancherClusters);
+    this.resourcesData[ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES] = allDispatches.managedOsImages;
+    this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR] = allDispatches.machineInvSelector;
+
+    // we need to check for the length of the response
+    // due to some issue with a standard-user, which can list apps
+    // but the list comes up empty []
+    const isElementalOperatorNotInstalledOnApps = allDispatches.installedApps && allDispatches.installedApps.length && !allDispatches.installedApps.find(item => item.id.includes('elemental-operator'));
+
+    // check if CRD is there but operator isn't
+    if (allDispatches.elementalSchema && isElementalOperatorNotInstalledOnApps) {
+      this.isElementalOpNotInstalledAndHasSchema = true;
+    }
+  },
+  data() {
+    return {
+      ELEMENTAL_CLUSTERS:                    'elementalClusters',
+      isElementalOpNotInstalledAndHasSchema: false,
+      resourcesData:                         {
+        [`${ ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }`]: [],
+        [`${ ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES }`]:   [],
+        [`${ this.ELEMENTAL_CLUSTERS }`]:                    [],
+        [`${ ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }`]:     [],
+        [`${ ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR }`]:  [],
+      },
+      machineInvCrd:                         ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES,
+      machineRegTitle:                       this.t(`typeLabel."${ ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }"`, { count: 2 }),
+      managedOsTitle:                        this.t(`typeLabel."${ ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }"`, { count: 2 }),
+      machineRegListLocation:                createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
+      machineRegCreateLocation:              createElementalRoute('resource-create', { resource: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
+      managedOsListLocation:                 createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
+      managedOsCreateLocation:               createElementalRoute('resource-create', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
+      machineRegHeaders:                     [
+        NAME,
+        {
+          name:     'token',
+          labelKey: 'tableHeaders.token',
+          value:    'status.registrationToken',
+          getValue: row => row.status?.registrationToken,
+          sort:     'status.registrationToken'
+        }
+      ],
+      managedOsHeaders:  [
+        NAME,
+        {
+          name:          'OsVersion',
+          labelKey:      'tableHeaders.osVersion',
+          value:         'spec.managedOSVersionName',
+          getValue:      row => row.spec.managedOSVersionName || '---',
+          sort:          ['spec.managedOSVersionName']
+        },
+        {
+          name:          'TargetClusters',
+          labelKey:      'tableHeaders.targetClusters',
+          value:         'clusterTargetsList',
+          getValue:      row => row.clusterTargetsList || '---',
+          sort:          ['clusterTargetsList']
+        },
+      ],
+      colorStops: {
+        0: '--error', 20: '--warning', 75: '--info', 95: '--success'
+      }
+    };
+  },
+  computed: {
+    cards() {
+      const out = [];
+
+      // create route
+      const clusterCreateRoute = {
+        name:   'c-cluster-product-resource-create',
+        params: {
+          resource: CAPI.RANCHER_CLUSTER,
+          product:  'manager',
+        },
+        query: { type: ELEMENTAL_CLUSTER_PROVIDER }
+      };
+
+      // manage route
+      const clusterManageRoute = {
+        name:   'c-cluster-product-resource',
+        params: {
+          resource: CAPI.RANCHER_CLUSTER,
+          product:  'manager',
+        },
+        query: { q: KIND.MACHINE_INV_SELECTOR_TEMPLATES }
+      };
+
+      // create cards objs
+      [
+        ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
+        ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES,
+        this.ELEMENTAL_CLUSTERS
+      ].forEach((type) => {
+        const obj = {
+          type,
+          count:       this.resourcesData[type]?.length || 0,
+          title:       this.t(`typeLabel."${ type }"`, { count: 2 }),
+          btnLabel:    this.t(`elemental.dashboard.btnLabel.${ this.resourcesData[type]?.length ? 'manage' : 'create' }."${ type }"`),
+          btnRoute:    createElementalRoute(`resource${ !this.resourcesData[type]?.length ? '-create' : '' }`, { resource: type }),
+          btnDisabled: false,
+          btnVisible:  true
+        };
+
+        if (type === this.ELEMENTAL_CLUSTERS && obj.count > 0) {
+          obj.btnRoute = clusterManageRoute;
+        } else if (type === this.ELEMENTAL_CLUSTERS) {
+          obj.btnRoute = clusterCreateRoute;
+        }
+
+        out.push(obj);
+      });
+
+      return out;
+    },
+    machineRegRows() {
+      const data = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS];
+
+      if (data?.length > MAX_ITEMS_PER_TABLE) {
+        return data.slice(0, MAX_ITEMS_PER_TABLE);
+      }
+
+      return data || [];
+    },
+    managedOsRows() {
+      const data = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES];
+
+      if (data?.length > MAX_ITEMS_PER_TABLE) {
+        return data.slice(0, MAX_ITEMS_PER_TABLE);
+      }
+
+      return data || [];
+    },
+    percentageBarValue() {
+      const total = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES]?.length || 0;
+
+      if (!this.used || !total) {
+        return 0;
+      }
+
+      return (this.used * 100) / total;
+    },
+    free() {
+      return this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES]?.length ? this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES]?.length - this.used : 0;
+    },
+    used() {
+      const clusterAssignedInventories = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].filter(item => item.clusterName);
+
+      return clusterAssignedInventories?.length || 0;
+    },
+    registrationEndpoints() {
+      return this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS] || [];
+    }
+  },
+  methods: {
+    handleRoute(card) {
+      if (!card.btnDisabled) {
+        this.$router.push(card.btnRoute);
+      }
+    },
+    async downloadMachineReg(item, btnCb) {
+      try {
+        await item.downloadMachineRegistration();
+        btnCb(true);
+      } catch (e) {
+        console.error('Failed to download file', e); // eslint-disable-line no-console
+
+        btnCb(false);
+      }
+    },
+    formatDataTestid(item) {
+      try {
+        return item.toLowerCase().replace(/\s/g, '-');
+      } catch (error) {
+        return 'name-not-generated';
+      }
+    }
+  },
+};
+</script>
+
+<template>
+  <div>
+    <Banner
+      v-if="isElementalOpNotInstalledAndHasSchema"
+      v-clean-html="t('product.notInstalledHasSchema', {}, true)"
+      class="mb-20"
+      color="warning"
+      data-testid="warning-not-install-with-schema"
+    />
+    <h1 class="title" data-testid="elemental-main-title">
+      {{ t('elemental.menuLabels.titleDashboard') }}
+    </h1>
+    <!-- Top cards -->
+    <div class="main-card-container">
+      <div
+        v-for="card, index in cards"
+        :key="index"
+        :data-testid="`card-${formatDataTestid(card.title)}`"
+        class="card"
+      >
+        <div class="card-top-block">
+          <h1>{{ card.count }}</h1>
+          <p>{{ card.title }}</p>
+        </div>
+        <button
+          v-if="card.type !== machineInvCrd || (card.type === machineInvCrd && !card.count)"
+          type="button"
+          class="btn role-secondary"
+          :data-testid="`button-${formatDataTestid(card.btnLabel)}`"
+          :class="{disabled: card.btnDisabled}"
+          @click="handleRoute(card)"
+        >
+          {{ card.btnLabel }}
+        </button>
+        <div
+          v-else
+          class="used-percentage-container mt-10"
+        >
+          <div>
+            <p>{{ t('elemental.dashboard.used') }}<span>{{ used }}</span></p>
+            <p>{{ t('elemental.dashboard.free') }}<span>{{ free }}</span></p>
+          </div>
+          <PercentageBar
+            class="mt-10"
+            :value="percentageBarValue"
+            :color-stops="colorStops"
+          />
+        </div>
+      </div>
+    </div>
+    <!-- Build ISO interface -->
+    <div class="mt-20 mb-20">
+      <BuildIso
+        :registration-endpoint-list="registrationEndpoints"
+      />
+    </div>
+    <!-- Tables -->
+    <div class="main-tables-container mb-40 mt-40">
+      <div
+        class="table-list"
+        data-testid="machine-reg-block"
+      >
+        <div class="table-title-block">
+          <h3 class="mb-20">
+            {{ machineRegTitle }}
+          </h3>
+          <nuxt-link
+            :to="machineRegListLocation"
+            class="table-title-block-link"
+            data-testid="manage-reg-btn"
+          >
+            {{ t('elemental.dashboard.manageReg') }}
+          </nuxt-link>
+        </div>
+        <div
+          v-if="machineRegRows?.length === 0"
+          class="empty-table-state"
+        >
+          <p>{{ t('elemental.dashboard.noMachineReg') }}</p>
+          <nuxt-link
+            :to="machineRegCreateLocation"
+            data-testid="create-machine-reg-btn"
+          >
+            {{ t('elemental.dashboard.noMachineRegAction') }}
+          </nuxt-link>
+        </div>
+        <ResourceTable
+          v-else
+          :rows="machineRegRows"
+          :headers="machineRegHeaders"
+          :search="false"
+          :table-actions="false"
+          :row-actions="true"
+          key-field="key"
+        >
+          <template #col:token="{row}">
+            <td class="token-truncate">
+              {{ row.status.registrationToken }}
+            </td>
+          </template>
+        </ResourceTable>
+      </div>
+      <div
+        class="table-list"
+        data-testid="update-group-block"
+      >
+        <div class="table-title-block">
+          <h3 class="mb-20">
+            {{ managedOsTitle }}
+          </h3>
+          <nuxt-link
+            :to="managedOsListLocation"
+            class="table-title-block-link"
+            data-testid="manage-update-group-btn"
+          >
+            {{ t('elemental.dashboard.manageOsImageUpgrade') }}
+          </nuxt-link>
+        </div>
+        <div
+          v-if="managedOsRows?.length === 0"
+          class="empty-table-state"
+        >
+          <p>{{ t('elemental.dashboard.noManageOs') }}</p>
+          <nuxt-link
+            :to="managedOsCreateLocation"
+            data-testid="create-update-group-btn"
+          >
+            {{ t('elemental.dashboard.noManageOsAction') }}
+          </nuxt-link>
+        </div>
+        <ResourceTable
+          v-else
+          :rows="managedOsRows"
+          :headers="managedOsHeaders"
+          :search="false"
+          :table-actions="false"
+          :row-actions="true"
+          key-field="key"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.title {
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  margin: 20px 0 20px 0;
+}
+
+.main-card-container {
+  display: flex;
+  flex-wrap: wrap;
+
+  .card {
+    width: fit-content;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    border: 1px solid var(--border);
+    margin: 0 10px 20px 10px;
+    padding: 20px;
+    height: 141px;
+
+    &:first-child {
+      margin-left: 0;
+    }
+    &:last-child {
+      margin-right: 0;
+    }
+
+    .card-top-block {
+      display: flex;
+      align-items: center;
+      margin-bottom: 20px;
+
+      h1 {
+        margin: 0 15px 0 0;
+        font-weight: bold;
+      }
+
+      p {
+        font-size: 18px;
+        font-weight: bold;
+      }
+    }
+
+    button {
+      justify-content: center;
+      width: fit-content;
+      font-weight: bold;
+      margin-top: 12px;
+    }
+  }
+
+  .used-percentage-container {
+    > div {
+      display: flex;
+      justify-content: space-between;
+
+      span {
+        font-size: 12px;
+        padding-left: 10px;
+        color: var(--muted);
+      }
+    }
+  }
+}
+
+.link {
+  cursor: pointer;
+}
+
+.empty-table-state {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 60px 0;
+
+  p {
+    margin-bottom: 20px;
+  }
+}
+
+.main-tables-container {
+  display: flex;
+  .table-list {
+    width: 50%;
+
+    &:first-child {
+      margin-right: 10px;
+    }
+    &:last-child {
+      margin-left: 10px;
+    }
+
+    .table-title-block {
+      display: flex;
+      justify-content: space-between;
+    }
+    .table-title-block-link {
+      margin-top: 2px;
+    }
+
+    .token-truncate {
+      max-width: 180px;
+      width: 60%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
+::v-deep .main-tables-container {
+ .download-machine-reg {
+    display: flex;
+    justify-content: center;
+    height: 59px;
+    min-width: 130px;
+
+    .icon.icon-lg {
+      display: none;
+    }
+  }
+}
+
+@media screen and (max-width: 1080px) {
+  .main-tables-container {
+    flex-direction: column;
+
+    .table-list {
+      width: 100%;
+      margin: 0 0 20px 0 !important;
+    }
+  }
+
+  .main-card-container .card {
+    &:nth-child(2) {
+      margin: 0 0 20px 10px;
+    }
+    &:last-child {
+      width: 100%;
+      margin: 0 0 20px 0;
+    }
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .main-card-container .card {
+    &:first-child, &:nth-child(2) {
+      width: 100%;
+      margin: 0 0 20px 0;
+    }
+  }
+}
+</style>

--- a/pkg/elemental/components/InstallView.vue
+++ b/pkg/elemental/components/InstallView.vue
@@ -1,0 +1,291 @@
+<script>
+import { mapGetters } from 'vuex';
+import { allHash } from '@shell/utils/promise';
+
+import { Banner } from '@components/Banner';
+import AsyncButton from '@shell/components/AsyncButton';
+import Loading from '@shell/components/Loading';
+
+import { CATALOG } from '@shell/config/types';
+import {
+  REPO_TYPE, REPO, CHART, VERSION, LOCAL
+} from '@shell/config/query-params';
+
+import { ELEMENTAL_REPO, ELEMENTAL_CHARTS } from '../config/elemental-types';
+import { handleGrowl, getLatestStableVersion } from '../utils/elemental-utils';
+
+export default {
+  name:       'ElementalOpNotInstalled',
+  components: {
+    Banner, AsyncButton, Loading
+  },
+  async fetch() {
+    this.reloadReady = false;
+    const reqs = {};
+
+    // if (this.$store.getters['management/canList'](CATALOG.APP)) {
+    //   reqs.apps = this.$store.dispatch('management/findAll', { type: CATALOG.APP });
+    // }
+
+    if (this.$store.getters['management/canList'](CATALOG.CLUSTER_REPO)) {
+      reqs.repos = this.$store.dispatch('management/findAll', { type: CATALOG.CLUSTER_REPO });
+    }
+
+    // force the refresh of the catalog to populate the charts
+    if ( !this.elementalRepo || !this.operatorChart ) {
+      reqs.catalogRefresh = this.$store.dispatch('catalog/refresh');
+    }
+
+    const allDispatches = await allHash(reqs);
+
+    this.initLoading = false;
+
+    console.log('INSTALL VIEW FETCH', allDispatches);
+  },
+  data() {
+    return { reloadReady: false, initLoading: true };
+  },
+  computed:   {
+    ...mapGetters({
+      charts: 'catalog/charts', repos: 'catalog/repos', t: 'i18n/t'
+    }),
+
+    elementalRepo() {
+      console.log('elemental repo chart', this.charts?.find(chart => chart.chartName.includes('elemental')));
+      const chart = this.charts?.find(chart => chart.chartName === ELEMENTAL_CHARTS.OPERATOR);
+
+      console.log('elemental repo chart', chart);
+      console.log('elemental repo this.repos', this.repos);
+
+      return this.repos?.find(repo => repo.id === chart?.repoName);
+    },
+
+    operatorChart() {
+      if ( this.elementalRepo ) {
+        return this.$store.getters['catalog/chart']({
+          repoName:  this.elementalRepo.id,
+          repoType:  'cluster',
+          chartName: ELEMENTAL_CHARTS.OPERATOR
+        });
+      }
+
+      return null;
+    },
+
+  },
+  methods: {
+    async addRepository(btnCb) {
+      try {
+        const repoObj = await this.$store.dispatch('management/create', {
+          type:     CATALOG.CLUSTER_REPO,
+          metadata: { name: 'elemental-operator-charts' },
+          spec:     {
+            gitBranch: ELEMENTAL_REPO.BRANCH,
+            gitRepo:   ELEMENTAL_REPO.REPO
+          },
+        });
+
+        try {
+          await repoObj.save();
+        } catch (e) {
+          handleGrowl({ error: e, store: this.$store });
+          btnCb(false);
+
+          return;
+        }
+
+        await this.refreshCharts();
+        btnCb(true);
+      } catch (e) {
+        handleGrowl({ error: e, store: this.$store });
+        btnCb(false);
+      }
+    },
+
+    async refreshCharts(retry = 0, init) {
+      try {
+        await this.$store.dispatch('catalog/refresh');
+      } catch (e) {
+        handleGrowl({ error: e, store: this.$store });
+      }
+
+      if ( !this.operatorChart && retry === 0 ) {
+        await this.$store.dispatch('management/findAll', { type: CATALOG.CLUSTER_REPO });
+        await this.refreshCharts(retry + 1);
+      }
+
+      if ( !this.operatorChart && retry === 1 && !init ) {
+        this.reloadReady = true;
+      }
+    },
+
+    async chartRoute() {
+      if ( !this.operatorChart ) {
+        try {
+          await this.refreshCharts();
+        } catch (e) {
+          handleGrowl({ error: e, store: this.$store });
+
+          return;
+        }
+      }
+
+      const {
+        repoType, repoName, chartName, versions
+      } = this.operatorChart;
+
+      console.log('chartRoute this.operatorChart', this.operatorChart);
+
+      const latestStableVersion = getLatestStableVersion(versions);
+
+      console.log('chartRoute latestStableVersion', latestStableVersion);
+
+      if ( latestStableVersion ) {
+        const query = {
+          [REPO_TYPE]: repoType,
+          [REPO]:      repoName,
+          [CHART]:     chartName,
+          [VERSION]:   latestStableVersion.version
+        };
+
+        console.log('chartRoute query', query);
+        // https://localhost:8005/c/local/apps/charts/install?repo-type=cluster&repo=elemental-operator-charts&chart=elemental-operator&version=1.3.5
+
+        this.$router.push({
+          name:   'c-cluster-apps-charts-install',
+          params: { cluster: LOCAL },
+          query,
+        });
+      } else {
+        const error = {
+          _statusText: this.t('elemental.versionError.title'),
+          message:     this.t('elemental.versionError.message')
+        };
+
+        handleGrowl({ error, store: this.$store });
+      }
+    },
+
+    reload() {
+      this.$router.go();
+    }
+  },
+};
+</script>
+
+<template>
+  <div
+    class="not-installed p-10"
+  >
+    <div class="elemental-logo mt-20 mb-10">
+      <svg
+        width="32"
+        height="32"
+        version="1.1"
+        viewBox="0 0 32 32"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:cc="http://creativecommons.org/ns#"
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        data-testid="elemental-icon"
+      >
+        <path d="m19.815 1.7301c-2.58 2.1868-5.2054 4.4095-7.1117 7.2308-1.5421-0.68689-2.4041-1.4374-3.9591-2.2561 0.10575 2.5182-1.0485 8.1467-1.0485 8.1467s-2.7364-1.1426-3.4544-1.7499c-1.5094 7.5704 1.5423 14.516 4.2174 15.512-2.4346-4.0904-1.9532-8.383-2.2783-11.922 0.70834 0.19817 3.2167 1.3552 3.2167 1.3552s1.5349-5.2704 1.7657-7.1474c0.35588-0.17673 2.2587 1.5699 2.2587 1.5699s4.4942-6.3785 4.9654-5.855c0.24957 3.0538 2.4639 5.9451 2.7831 8.7771 1.1229-0.43788 2.251-1.099 3.3739-1.5369 1.2859 2.0276 1.593 4.6848 0.87919 15.125 1.7074-3.9645 2.4989-7.1695 2.7194-10.871 0.15218-2.5549-0.68846-5.5109-1.2476-8.0962-1.0528 0.41053-2.6801 0.992-3.7329 1.4026-1.3899-3.5546-2.8209-6.3417-3.3472-9.6853z" stroke-width="1.1688" />
+        <path d="m16.166 12.71s-0.30557 1.4187-1.0714 2.7058c-1.5366 2.5826-1.9658 3.1325-2.7518 4.6113-0.91122 1.7142-2.0904 3.5459-1.7735 5.4203 0.29322 1.7348 1.575 3.5224 3.1994 4.1986 2.3952 0.99716 5.9631 0.89724 7.7171-1.0146 1.4273-1.5558 1.5035-4.605 0.2828-6.3275-0.93748-1.323-2.0922-3.0908-3.0321-4.7013-0.92852-1.5911-2.5703-4.8926-2.5703-4.8926zm-2.6097 11.247c0.32254 0.9525 0.60977 1.4545 1.168 1.9787 0.69835 0.65574 1.3022 1.036 2.5617 1.3025l-0.04756 1.4089c-0.84539-0.09897-2.7005-0.3863-3.6463-1.257-0.884-0.8138-1.4935-2.0246-1.4519-3.2991z" stroke-width="1.1688" />
+      </svg>
+    </div>
+    <h1 class="mb-20">
+      {{ t("product.elemental") }}
+    </h1>
+    <p
+      v-clean-html="t('product.description', {}, true)"
+      class="description"
+      data-testid="elemental-description-text"
+    />
+    <Banner
+      v-clean-html="t('product.notInstalledOrNoSchema', {}, true)"
+      class="mt-20 mb-40"
+      color="warning"
+      data-testid="warning-not-install-or-no-schema"
+    />
+
+    <div class="relative">
+      <Loading
+        v-if="initLoading"
+        mode="relative"
+        class="mt-20"
+      />
+
+      <!-- Add repo btn -->
+      <div v-else-if="!elementalRepo">
+        <AsyncButton
+          mode="elementalRepository"
+          data-testid="repo-add-button"
+          @click="addRepository"
+        />
+      </div>
+
+      <!-- Install charts -->
+      <div
+        v-else
+        class="relative"
+      >
+        <Loading
+          v-if="!operatorChart && !reloadReady"
+          mode="relative"
+          class="mt-20"
+        />
+
+        <div v-else-if="!operatorChart && reloadReady">
+          <Banner color="warning">
+            <span class="mb-20">
+              {{ t('elemental.appInstall.reload' ) }}
+            </span>
+            <button class="ml-10 btn btn-sm role-primary" @click="reload()">
+              {{ t('generic.reload') }}
+            </button>
+          </Banner>
+        </div>
+
+        <button
+          v-else
+          data-testid="charts-install-button"
+          class="btn role-primary mt-20"
+          :disabled="!operatorChart"
+          @click.prevent="chartRoute"
+        >
+          {{ t("elemental.appInstall.button") }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+body.theme-dark .elemental-logo svg {
+  fill: var(--body-text);
+}
+</style>
+
+<style lang="scss" scoped>
+.not-installed {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  margin: 100px 0;
+
+  .elemental-logo svg {
+    transform: scale(1.5);
+  }
+
+  .description {
+    line-height: 20px;
+  }
+}
+
+.relative {
+  position: relative;
+}
+</style>

--- a/pkg/elemental/config/elemental-types.js
+++ b/pkg/elemental/config/elemental-types.js
@@ -13,3 +13,10 @@ export const ELEMENTAL_SCHEMA_IDS = {
 };
 
 export const KIND = { MACHINE_INV_SELECTOR_TEMPLATES: 'MachineInventorySelectorTemplate' };
+
+export const ELEMENTAL_REPO = {
+  REPO:   'https://github.com/rancher/elemental-operator',
+  BRANCH: 'gh-pages'
+};
+
+export const ELEMENTAL_CHARTS = { OPERATOR: 'elemental-operator' };

--- a/pkg/elemental/config/elemental-types.js
+++ b/pkg/elemental/config/elemental-types.js
@@ -19,4 +19,4 @@ export const ELEMENTAL_REPO = {
   BRANCH: 'gh-pages'
 };
 
-export const ELEMENTAL_CHARTS = { OPERATOR: 'elemental-operator' };
+export const ELEMENTAL_CHARTS = { OPERATOR: 'elemental' };

--- a/pkg/elemental/detail/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/detail/elemental.cattle.io.machineregistration.vue
@@ -122,7 +122,7 @@ export default {
     >
       <div class="col span-12">
         <h3>{{ t('elemental.machineRegistration.edit.imageSetup') }}</h3>
-        <p v-html="t('elemental.machineRegistration.edit.downloadMachineRegistrationFile', {}, true)" />
+        <p v-clean-html="t('elemental.machineRegistration.edit.downloadMachineRegistrationFile', {}, true)" />
         <AsyncButton
           class="mt-10"
           mode="downloadMachineReg"

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -232,10 +232,10 @@ export default {
             :weight="3"
           >
             <Banner
+              v-clean-html="t('elemental.machineRegistration.create.labelsAndAnnotationsMachInvBanner', {}, true)"
               class="mb-40"
               color="info"
               data-testid="mach-inv-banner"
-              v-html="t('elemental.machineRegistration.create.labelsAndAnnotationsMachInvBanner', {}, true)"
             />
             <div class="row mb-30">
               <KeyValue
@@ -271,10 +271,10 @@ export default {
             :weight="2"
           >
             <Banner
+              v-clean-html="t('elemental.machineRegistration.create.labelsAndAnnotationsMachRegBanner', {}, true)"
               class="mb-40"
               color="info"
               data-testid="mach-reg-banner"
-              v-html="t('elemental.machineRegistration.create.labelsAndAnnotationsMachRegBanner', {}, true)"
             />
             <div class="row mb-30">
               <KeyValue

--- a/pkg/elemental/index.ts
+++ b/pkg/elemental/index.ts
@@ -3,6 +3,12 @@ import { IPlugin } from '@shell/core/types';
 import elementalRouting from './routing/elemental-routing';
 import elementalStore from './store/elemental-store';
 
+// fix missing directives on dashboard v2.7.2
+// doesn't seem to have any side effect while runnning on v2.7-head
+// where the directive is already present
+import '@shell/plugins/clean-tooltip-directive';
+import '@shell/plugins/clean-html-directive';
+
 // Init the package
 export default function($plugin: IPlugin) {
   // Auto-import model, detail, edit from the folders

--- a/pkg/elemental/index.ts
+++ b/pkg/elemental/index.ts
@@ -3,12 +3,6 @@ import { IPlugin } from '@shell/core/types';
 import elementalRouting from './routing/elemental-routing';
 import elementalStore from './store/elemental-store';
 
-// fix missing directives on dashboard v2.7.2
-// doesn't seem to have any side effect while runnning on v2.7-head
-// where the directive is already present
-import '@shell/plugins/clean-tooltip-directive';
-import '@shell/plugins/clean-html-directive';
-
 // Init the package
 export default function($plugin: IPlugin) {
   // Auto-import model, detail, edit from the folders

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -1,7 +1,7 @@
 product:
   elemental: OS Management
   description: "Elemental is a software stack enabling a centralized, full cloud-native OS management with Kubernetes. <br><br> Cluster Node OSes are built and maintained via container images through the Elemental Toolkit and installed on new hosts using the Elemental CLI. <br><br> The Elemental Operator and the Rancher System Agent enable Rancher Manager to fully control Elemental clusters, from the installation and management of the OS on the Nodes to the provisioning of new K3s or RKE2 clusters in a centralized way."
-  notInstalledOrNoSchema: Either the user doesn't have enough permissions to run the OS Management extension or the Elemental Operator is not installed (required to run the OS Management extension). <br><br> For user permissions, check with your Rancher administrator if the correct role is assigned. To install Elemental Operator please follow the instructions on the official <a target="blank" href="https://elemental.docs.rancher.com/quickstart-cli#install-elemental-operator" target="_blank" rel="noopener nofollow">documentation</a>.
+  notInstalledOrNoSchema: Either the user doesn't have enough permissions to run the OS Management extension or the Elemental Operator is not installed (required to run the OS Management extension). <br><br> For user permissions, check with your Rancher administrator if the correct role is assigned. To install Elemental Operator please click the button below.
   notInstalledHasSchema: The Elemental Operator is required to run the OS Management extension. To install it please follow the instructions on the official <a target="blank" href="https://elemental.docs.rancher.com/quickstart-cli#install-elemental-operator" target="_blank" rel="noopener nofollow">documentation</a>.
 
 cluster:
@@ -69,6 +69,10 @@ typeLabel:
   elementalClusters: Clusters
 
 asyncButton:
+  elementalRepository:
+    action: Add Elemental Repository
+    success: Added
+    waiting: Adding&hellip;
   downloadMachineReg:
     action: Download Configuration File
     waiting: Preparing..
@@ -87,6 +91,12 @@ description:
   elementalClusters: Clusters managed by Elemental
 
 elemental:
+  appInstall:
+    button: Install Elemental Operator
+    reload: Unable to fetch Elemental Operator Helm chart - reload required
+  versionError:
+      title: Chart Version not found.
+      message: Unable to determine the latest stable version of the elemental chart. Please make sure the Helm repository
   menuLabels:
     dashboard: Dashboard
     titleDashboard: OS Management Dashboard

--- a/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
+++ b/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
@@ -127,11 +127,11 @@ export default {
       @input="matchChanged($event)"
     />
     <Banner v-if="matchingMachineInventories" :color="(matchingMachineInventories.isNone || matchingMachineInventories.isAll ? 'warning' : 'success')">
-      <span v-if="matchingMachineInventories.isAll" v-html="t('elemental.clusterGroup.selector.matchesAll', matchingMachineInventories)" />
-      <span v-else-if="matchingMachineInventories.isNone" v-html="t('elemental.clusterGroup.selector.matchesNone', matchingMachineInventories)" />
+      <span v-if="matchingMachineInventories.isAll" v-clean-html="t('elemental.clusterGroup.selector.matchesAll', matchingMachineInventories)" />
+      <span v-else-if="matchingMachineInventories.isNone" v-clean-html="t('elemental.clusterGroup.selector.matchesNone', matchingMachineInventories)" />
       <span
         v-else
-        v-html="t('elemental.clusterGroup.selector.matchesSome', matchingMachineInventories)"
+        v-clean-html="t('elemental.clusterGroup.selector.matchesSome', matchingMachineInventories)"
       />
     </Banner>
   </div>

--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental",
   "description": "OS Management extension",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -1,42 +1,28 @@
 <script>
 import { allHash } from '@shell/utils/promise';
-import Loading from '@shell/components/Loading';
-import { CAPI, CATALOG } from '@shell/config/types';
-import { NAME } from '@shell/config/table-headers';
-import ResourceTable from '@shell/components/ResourceTable';
-import PercentageBar from '@shell/components/PercentageBar';
-import { Banner } from '@components/Banner';
-import {
-  ELEMENTAL_SCHEMA_IDS,
-  ELEMENTAL_CLUSTER_PROVIDER,
-  KIND
-} from '../config/elemental-types';
-import { createElementalRoute } from '../utils/custom-routing';
-import { filterForElementalClusters } from '../utils/elemental-utils';
-import BuildIso from '../components/BuildIso';
 
-const MAX_ITEMS_PER_TABLE = 6;
+import { CATALOG } from '@shell/config/types';
+
+import Loading from '@shell/components/Loading';
+
+import InstallView from '../components/InstallView';
+// import InstallView from '../components/InstallView';
+import DashboardView from '../components/DashboardView';
+
+import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
 
 export default {
-  name:       'Dashboard',
+  name:       'BaseView',
   components: {
-    Loading, Banner, PercentageBar, ResourceTable, BuildIso
+    Loading,
+    InstallView,
+    // InstallView,
+    DashboardView
   },
   async fetch() {
     // this covers scenario where Elemental Operator is deleted from Apps and we lose the Elemental Admin role for Standard Users...
     if (this.$store.getters['management/canList'](ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS)) {
-      const requests = {
-        // needed for table
-        machineRegistrations: this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
-        // needed for resource gauge
-        machineInventories:   this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES }),
-        rancherClusters:      this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
-        // needed for table
-        managedOsImages:      this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
-        // needed to populate cluster name col on machine inventories list
-        machineInvSelector:   this.$store.dispatch(`management/findAll`, { type: ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR }),
-        elementalSchema:      this.$store.getters['management/schemaFor'](ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES)
-      };
+      const requests = { elementalSchema: this.$store.getters['management/schemaFor'](ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES) };
 
       // needed to check if operator is installed
       if (this.$store.getters['management/canList'](CATALOG.APP)) {
@@ -45,186 +31,24 @@ export default {
 
       const allDispatches = await allHash(requests);
 
-      this.resourcesData = {};
-
-      this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS] = allDispatches.machineRegistrations;
-      this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES] = allDispatches.machineInventories;
-      this.resourcesData[this.ELEMENTAL_CLUSTERS] = filterForElementalClusters(allDispatches.rancherClusters);
-      this.resourcesData[ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES] = allDispatches.managedOsImages;
-      this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INV_SELECTOR] = allDispatches.machineInvSelector;
+      console.log('allDispatches', allDispatches);
 
       // we need to check for the length of the response
       // due to some issue with a standard-user, which can list apps
       // but the list comes up empty []
-      const isElementalOperatorNotInstalledOnApps = allDispatches.installedApps && allDispatches.installedApps.length && !allDispatches.installedApps.find(item => item.id.includes('elemental-operator'));
+      const isElementalOperatorNotInstalledOnApps = allDispatches.installedApps?.length && !allDispatches.installedApps.find(item => item.id.includes('elemental-operator'));
 
       // check if operator is installed
       if (!allDispatches.elementalSchema || isElementalOperatorNotInstalledOnApps) {
         this.isElementalOpInstalled = false;
-      }
-      // check if CRD is there but operator isn't
-      if (allDispatches.elementalSchema && isElementalOperatorNotInstalledOnApps) {
-        this.isElementalOpNotInstalledAndHasSchema = true;
       }
     } else {
       this.isElementalOpInstalled = false;
     }
   },
   data() {
-    return {
-      isElementalOpInstalled:                true,
-      isElementalOpNotInstalledAndHasSchema: false,
-      ELEMENTAL_CLUSTERS:                    'elementalClusters',
-      machineInvCrd:                         ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES,
-      machineRegTitle:                       this.t(`typeLabel."${ ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }"`, { count: 2 }),
-      managedOsTitle:                        this.t(`typeLabel."${ ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }"`, { count: 2 }),
-      machineRegListLocation:                createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
-      machineRegCreateLocation:              createElementalRoute('resource-create', { resource: ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }),
-      managedOsListLocation:                 createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
-      managedOsCreateLocation:               createElementalRoute('resource-create', { resource: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES }),
-      machineRegHeaders:                     [
-        NAME,
-        {
-          name:     'token',
-          labelKey: 'tableHeaders.token',
-          value:    'status.registrationToken',
-          getValue: row => row.status?.registrationToken,
-          sort:     'status.registrationToken'
-        }
-      ],
-      managedOsHeaders:  [
-        NAME,
-        {
-          name:          'OsVersion',
-          labelKey:      'tableHeaders.osVersion',
-          value:         'spec.managedOSVersionName',
-          getValue:      row => row.spec.managedOSVersionName || '---',
-          sort:          ['spec.managedOSVersionName']
-        },
-        {
-          name:          'TargetClusters',
-          labelKey:      'tableHeaders.targetClusters',
-          value:         'clusterTargetsList',
-          getValue:      row => row.clusterTargetsList || '---',
-          sort:          ['clusterTargetsList']
-        },
-      ],
-      colorStops: {
-        0: '--error', 20: '--warning', 75: '--info', 95: '--success'
-      }
-    };
-  },
-  computed: {
-    cards() {
-      const out = [];
-
-      const clusterCreateRoute = {
-        name:   'c-cluster-product-resource-create',
-        params: {
-          resource: CAPI.RANCHER_CLUSTER,
-          product:  'manager',
-        },
-        query: { type: ELEMENTAL_CLUSTER_PROVIDER }
-      };
-
-      const clusterManageRoute = {
-        name:   'c-cluster-product-resource',
-        params: {
-          resource: CAPI.RANCHER_CLUSTER,
-          product:  'manager',
-        },
-        query: { q: KIND.MACHINE_INV_SELECTOR_TEMPLATES }
-      };
-
-      [
-        ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
-        ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES,
-        this.ELEMENTAL_CLUSTERS
-      ].forEach((type) => {
-        const obj = {
-          type,
-          count:       this.resourcesData[type]?.length || 0,
-          title:       this.t(`typeLabel."${ type }"`, { count: 2 }),
-          btnLabel:    this.t(`elemental.dashboard.btnLabel.${ this.resourcesData[type]?.length ? 'manage' : 'create' }."${ type }"`),
-          btnRoute:    createElementalRoute(`resource${ !this.resourcesData[type]?.length ? '-create' : '' }`, { resource: type }),
-          btnDisabled: false,
-          btnVisible:  true
-        };
-
-        if (type === this.ELEMENTAL_CLUSTERS && obj.count > 0) {
-          obj.btnRoute = clusterManageRoute;
-        } else if (type === this.ELEMENTAL_CLUSTERS) {
-          obj.btnRoute = clusterCreateRoute;
-        }
-
-        out.push(obj);
-      });
-
-      return out;
-    },
-    machineRegRows() {
-      const data = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS];
-
-      if (data.length > MAX_ITEMS_PER_TABLE) {
-        return data.slice(0, MAX_ITEMS_PER_TABLE);
-      }
-
-      return data;
-    },
-    managedOsRows() {
-      const data = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MANAGED_OS_IMAGES];
-
-      if (data.length > MAX_ITEMS_PER_TABLE) {
-        return data.slice(0, MAX_ITEMS_PER_TABLE);
-      }
-
-      return data;
-    },
-    percentageBarValue() {
-      const total = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].length || 0;
-
-      if (!this.used || !total) {
-        return 0;
-      }
-
-      return (this.used * 100) / total;
-    },
-    free() {
-      return this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].length ? this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].length - this.used : 0;
-    },
-    used() {
-      const clusterAssignedInventories = this.resourcesData[ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES].filter(item => item.clusterName);
-
-      return clusterAssignedInventories.length || 0;
-    },
-    registrationEndpoints() {
-      return this.resourcesData?.[ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS] || [];
-    }
-  },
-  methods: {
-    handleRoute(card) {
-      if (!card.btnDisabled) {
-        this.$router.push(card.btnRoute);
-      }
-    },
-    async downloadMachineReg(item, btnCb) {
-      try {
-        await item.downloadMachineRegistration();
-        btnCb(true);
-      } catch (e) {
-        console.error('Failed to download file', e); // eslint-disable-line no-console
-
-        btnCb(false);
-      }
-    },
-    formatDataTestid(item) {
-      try {
-        return item.toLowerCase().replace(/\s/g, '-');
-      } catch (error) {
-        return 'name-not-generated';
-      }
-    }
-  },
+    return { isElementalOpInstalled: true };
+  }
 };
 </script>
 
@@ -232,363 +56,13 @@ export default {
   <div>
     <Loading v-if="$fetchState.pending" />
     <!-- Elemental Operator not installed -->
-    <div
+    <InstallView
       v-else-if="!isElementalOpInstalled"
-      class="not-installed p-10"
-    >
-      <div class="elemental-logo mt-20 mb-10">
-        <svg
-          width="32"
-          height="32"
-          version="1.1"
-          viewBox="0 0 32 32"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:cc="http://creativecommons.org/ns#"
-          xmlns:dc="http://purl.org/dc/elements/1.1/"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          data-testid="elemental-icon"
-        >
-          <path d="m19.815 1.7301c-2.58 2.1868-5.2054 4.4095-7.1117 7.2308-1.5421-0.68689-2.4041-1.4374-3.9591-2.2561 0.10575 2.5182-1.0485 8.1467-1.0485 8.1467s-2.7364-1.1426-3.4544-1.7499c-1.5094 7.5704 1.5423 14.516 4.2174 15.512-2.4346-4.0904-1.9532-8.383-2.2783-11.922 0.70834 0.19817 3.2167 1.3552 3.2167 1.3552s1.5349-5.2704 1.7657-7.1474c0.35588-0.17673 2.2587 1.5699 2.2587 1.5699s4.4942-6.3785 4.9654-5.855c0.24957 3.0538 2.4639 5.9451 2.7831 8.7771 1.1229-0.43788 2.251-1.099 3.3739-1.5369 1.2859 2.0276 1.593 4.6848 0.87919 15.125 1.7074-3.9645 2.4989-7.1695 2.7194-10.871 0.15218-2.5549-0.68846-5.5109-1.2476-8.0962-1.0528 0.41053-2.6801 0.992-3.7329 1.4026-1.3899-3.5546-2.8209-6.3417-3.3472-9.6853z" stroke-width="1.1688" />
-          <path d="m16.166 12.71s-0.30557 1.4187-1.0714 2.7058c-1.5366 2.5826-1.9658 3.1325-2.7518 4.6113-0.91122 1.7142-2.0904 3.5459-1.7735 5.4203 0.29322 1.7348 1.575 3.5224 3.1994 4.1986 2.3952 0.99716 5.9631 0.89724 7.7171-1.0146 1.4273-1.5558 1.5035-4.605 0.2828-6.3275-0.93748-1.323-2.0922-3.0908-3.0321-4.7013-0.92852-1.5911-2.5703-4.8926-2.5703-4.8926zm-2.6097 11.247c0.32254 0.9525 0.60977 1.4545 1.168 1.9787 0.69835 0.65574 1.3022 1.036 2.5617 1.3025l-0.04756 1.4089c-0.84539-0.09897-2.7005-0.3863-3.6463-1.257-0.884-0.8138-1.4935-2.0246-1.4519-3.2991z" stroke-width="1.1688" />
-        </svg>
-      </div>
-      <h1 class="mb-20">
-        {{ t("product.elemental") }}
-      </h1>
-      <p
-        class="description"
-        data-testid="elemental-description-text"
-        v-html="t('product.description', {}, true)"
-      />
-      <Banner
-        class="mt-40"
-        color="warning"
-        data-testid="warning-not-install-or-no-schema"
-        v-html="t('product.notInstalledOrNoSchema', {}, true)"
-      />
-    </div>
-    <div v-else>
-      <Banner
-        v-if="isElementalOpNotInstalledAndHasSchema"
-        class="mb-20"
-        color="warning"
-        data-testid="warning-not-install-with-schema"
-        v-html="t('product.notInstalledHasSchema', {}, true)"
-      />
-      <h1 class="title" data-testid="elemental-main-title">
-        {{ t('elemental.menuLabels.titleDashboard') }}
-      </h1>
-      <!-- Top cards -->
-      <div class="main-card-container">
-        <div
-          v-for="card, index in cards"
-          :key="index"
-          :data-testid="`card-${formatDataTestid(card.title)}`"
-          class="card"
-        >
-          <div class="card-top-block">
-            <h1>{{ card.count }}</h1>
-            <p>{{ card.title }}</p>
-          </div>
-          <button
-            v-if="card.type !== machineInvCrd || (card.type === machineInvCrd && !card.count)"
-            type="button"
-            class="btn role-secondary"
-            :data-testid="`button-${formatDataTestid(card.btnLabel)}`"
-            :class="{disabled: card.btnDisabled}"
-            @click="handleRoute(card)"
-          >
-            {{ card.btnLabel }}
-          </button>
-          <div
-            v-else
-            class="used-percentage-container mt-10"
-          >
-            <div>
-              <p>{{ t('elemental.dashboard.used') }}<span>{{ used }}</span></p>
-              <p>{{ t('elemental.dashboard.free') }}<span>{{ free }}</span></p>
-            </div>
-            <PercentageBar
-              class="mt-10"
-              :value="percentageBarValue"
-              :color-stops="colorStops"
-            />
-          </div>
-        </div>
-      </div>
-      <!-- Build ISO interface -->
-      <div class="mt-20 mb-20">
-        <BuildIso
-          :registration-endpoint-list="registrationEndpoints"
-        />
-      </div>
-      <!-- Tables -->
-      <div class="main-tables-container mb-40 mt-40">
-        <div
-          class="table-list"
-          data-testid="machine-reg-block"
-        >
-          <div class="table-title-block">
-            <h3 class="mb-20">
-              {{ machineRegTitle }}
-            </h3>
-            <nuxt-link
-              :to="machineRegListLocation"
-              class="table-title-block-link"
-              data-testid="manage-reg-btn"
-            >
-              {{ t('elemental.dashboard.manageReg') }}
-            </nuxt-link>
-          </div>
-          <div
-            v-if="machineRegRows.length === 0"
-            class="empty-table-state"
-          >
-            <p>{{ t('elemental.dashboard.noMachineReg') }}</p>
-            <nuxt-link
-              :to="machineRegCreateLocation"
-              data-testid="create-machine-reg-btn"
-            >
-              {{ t('elemental.dashboard.noMachineRegAction') }}
-            </nuxt-link>
-          </div>
-          <ResourceTable
-            v-else
-            :rows="machineRegRows"
-            :headers="machineRegHeaders"
-            :search="false"
-            :table-actions="false"
-            :row-actions="true"
-            key-field="key"
-          >
-            <template #col:token="{row}">
-              <td class="token-truncate">
-                {{ row.status.registrationToken }}
-              </td>
-            </template>
-          </ResourceTable>
-        </div>
-        <div
-          class="table-list"
-          data-testid="update-group-block"
-        >
-          <div class="table-title-block">
-            <h3 class="mb-20">
-              {{ managedOsTitle }}
-            </h3>
-            <nuxt-link
-              :to="managedOsListLocation"
-              class="table-title-block-link"
-              data-testid="manage-update-group-btn"
-            >
-              {{ t('elemental.dashboard.manageOsImageUpgrade') }}
-            </nuxt-link>
-          </div>
-          <div
-            v-if="managedOsRows.length === 0"
-            class="empty-table-state"
-          >
-            <p>{{ t('elemental.dashboard.noManageOs') }}</p>
-            <nuxt-link
-              :to="managedOsCreateLocation"
-              data-testid="create-update-group-btn"
-            >
-              {{ t('elemental.dashboard.noManageOsAction') }}
-            </nuxt-link>
-          </div>
-          <ResourceTable
-            v-else
-            :rows="managedOsRows"
-            :headers="managedOsHeaders"
-            :search="false"
-            :table-actions="false"
-            :row-actions="true"
-            key-field="key"
-          />
-        </div>
-      </div>
-    </div>
+    />
+    <!-- Dashboard view -->
+    <DashboardView v-else />
   </div>
 </template>
 
-<style lang="scss">
-body.theme-dark .elemental-logo svg {
-  fill: var(--body-text);
-}
-</style>
-
 <style lang="scss" scoped>
-.not-installed {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  margin: 100px 0;
-
-  .elemental-logo svg {
-    transform: scale(1.5);
-  }
-
-  .description {
-    line-height: 20px;
-  }
-}
-
-.title {
-  padding-bottom: 10px;
-  border-bottom: 1px solid var(--border);
-  margin: 20px 0 20px 0;
-}
-
-.main-card-container {
-  display: flex;
-  flex-wrap: wrap;
-
-  .card {
-    width: fit-content;
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    border: 1px solid var(--border);
-    margin: 0 10px 20px 10px;
-    padding: 20px;
-    height: 141px;
-
-    &:first-child {
-      margin-left: 0;
-    }
-    &:last-child {
-      margin-right: 0;
-    }
-
-    .card-top-block {
-      display: flex;
-      align-items: center;
-      margin-bottom: 20px;
-
-      h1 {
-        margin: 0 15px 0 0;
-        font-weight: bold;
-      }
-
-      p {
-        font-size: 18px;
-        font-weight: bold;
-      }
-    }
-
-    button {
-      justify-content: center;
-      width: fit-content;
-      font-weight: bold;
-      margin-top: 12px;
-    }
-  }
-
-  .used-percentage-container {
-    > div {
-      display: flex;
-      justify-content: space-between;
-
-      span {
-        font-size: 12px;
-        padding-left: 10px;
-        color: var(--muted);
-      }
-    }
-  }
-}
-
-.link {
-  cursor: pointer;
-}
-
-.empty-table-state {
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 60px 0;
-
-  p {
-    margin-bottom: 20px;
-  }
-}
-
-.main-tables-container {
-  display: flex;
-  .table-list {
-    width: 50%;
-
-    &:first-child {
-      margin-right: 10px;
-    }
-    &:last-child {
-      margin-left: 10px;
-    }
-
-    .table-title-block {
-      display: flex;
-      justify-content: space-between;
-    }
-    .table-title-block-link {
-      margin-top: 2px;
-    }
-
-    .token-truncate {
-      max-width: 180px;
-      width: 60%;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-  }
-}
-
-::v-deep .main-tables-container {
- .download-machine-reg {
-    display: flex;
-    justify-content: center;
-    height: 59px;
-    min-width: 130px;
-
-    .icon.icon-lg {
-      display: none;
-    }
-  }
-}
-
-@media screen and (max-width: 1080px) {
-  .main-tables-container {
-    flex-direction: column;
-
-    .table-list {
-      width: 100%;
-      margin: 0 0 20px 0 !important;
-    }
-  }
-
-  .main-card-container .card {
-    &:nth-child(2) {
-      margin: 0 0 20px 10px;
-    }
-    &:last-child {
-      width: 100%;
-      margin: 0 0 20px 0;
-    }
-  }
-}
-
-@media screen and (max-width: 800px) {
-  .main-card-container .card {
-    &:first-child, &:nth-child(2) {
-      width: 100%;
-      margin: 0 0 20px 0;
-    }
-  }
-}
 </style>

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -31,8 +31,6 @@ export default {
 
       const allDispatches = await allHash(requests);
 
-      console.log('allDispatches', allDispatches);
-
       // we need to check for the length of the response
       // due to some issue with a standard-user, which can list apps
       // but the list comes up empty []

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -1,14 +1,8 @@
 <script>
-import { allHash } from '@shell/utils/promise';
-
 import { CATALOG } from '@shell/config/types';
-
 import Loading from '@shell/components/Loading';
-
 import InstallView from '../components/InstallView';
-// import InstallView from '../components/InstallView';
 import DashboardView from '../components/DashboardView';
-
 import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
 
 export default {
@@ -16,28 +10,26 @@ export default {
   components: {
     Loading,
     InstallView,
-    // InstallView,
     DashboardView
   },
   async fetch() {
     // this covers scenario where Elemental Operator is deleted from Apps and we lose the Elemental Admin role for Standard Users...
     if (this.$store.getters['management/canList'](ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS)) {
-      const requests = { elementalSchema: this.$store.getters['management/schemaFor'](ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES) };
-
+      let installedApps;
       // needed to check if operator is installed
       if (this.$store.getters['management/canList'](CATALOG.APP)) {
-        requests.installedApps = this.$store.dispatch('management/findAll', { type: CATALOG.APP });
+        installedApps = await this.$store.dispatch('management/findAll', { type: CATALOG.APP });
       }
 
-      const allDispatches = await allHash(requests);
+      const elementalSchema = this.$store.getters['management/schemaFor'](ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES)
 
       // we need to check for the length of the response
       // due to some issue with a standard-user, which can list apps
       // but the list comes up empty []
-      const isElementalOperatorNotInstalledOnApps = allDispatches.installedApps?.length && !allDispatches.installedApps.find(item => item.id.includes('elemental-operator'));
+      const isElementalOperatorNotInstalledOnApps = installedApps?.length && !installedApps?.find(item => item.id.includes('elemental-operator'));
 
       // check if operator is installed
-      if (!allDispatches.elementalSchema || isElementalOperatorNotInstalledOnApps) {
+      if (!elementalSchema || isElementalOperatorNotInstalledOnApps) {
         this.isElementalOpInstalled = false;
       }
     } else {

--- a/pkg/elemental/tsconfig.json
+++ b/pkg/elemental/tsconfig.json
@@ -16,7 +16,7 @@
     "typeRoots": [
       "../../node_modules",
       "../../node_modules/@rancher/shell/types"
-    ],    
+    ],
     "types": [
       "node",
       "webpack-env",

--- a/pkg/elemental/utils/elemental-utils.js
+++ b/pkg/elemental/utils/elemental-utils.js
@@ -1,3 +1,5 @@
+import semver from 'semver';
+import isEmpty from 'lodash/isEmpty';
 import { KIND } from '../config/elemental-types';
 
 export function filterForElementalClusters(clusters) {
@@ -19,4 +21,39 @@ export function filterForUsedElementalClustersOnManagedOs(elementalClusters, osG
   });
 
   return out;
+}
+
+export function getLatestStableVersion(versions) {
+  const allVersions = versions.map(v => v.version);
+  const stableVersions = versions.filter(v => !v.version.includes('rc'));
+
+  if ( isEmpty(stableVersions) && !isEmpty(allVersions) ) {
+    return semver.rsort(allVersions)[0];
+  }
+
+  return stableVersions?.sort((a, b) => {
+    const versionA = a.version.split('.').map(Number);
+    const versionB = b.version.split('.').map(Number);
+
+    for ( let i = 0; i < Math.max(versionA.length, versionB.length); i++ ) {
+      if ( versionA[i] === undefined || versionA[i] < versionB[i] ) {
+        return 1;
+      }
+      if ( versionB[i] === undefined || versionA[i] > versionB[i] ) {
+        return -1;
+      }
+    }
+
+    return 0;
+  })[0];
+}
+
+export function handleGrowl(config) {
+  const error = config.error?.data || config.error;
+
+  config.store.dispatch(`growl/${ config.type || 'error' }`, {
+    title:   error._statusText,
+    message: error.message,
+    timeout: 5000,
+  }, { root: true });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,7 +1006,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.19.4.tgz#95c86de137bf0317f3a570e1b6e996b427299747"
   integrity sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.0", "@babel/core@^7.12.16", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.4.4", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
+"@babel/core@^7.1.0", "@babel/core@^7.11.0", "@babel/core@^7.12.16", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
   version "7.19.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.3.tgz#2519f62a51458f43b682d61583c3810e7dcee64c"
   integrity sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==
@@ -1217,10 +1217,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+
 "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/helper-validator-identifier@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
+  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
 
 "@babel/helper-validator-option@^7.16.7", "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
@@ -1259,6 +1269,11 @@
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.4.tgz#03c4339d2b8971eb3beca5252bafd9b9f79db3dc"
   integrity sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==
+
+"@babel/parser@^7.20.7":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz#da950e622420bf96ca0d0f2909cdddac3acd8719"
+  integrity sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1849,7 +1864,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.14.1", "@babel/preset-env@^7.4.4":
+"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.14.1":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.19.4.tgz#4c91ce2e1f994f717efb4237891c3ad2d808c94b"
   integrity sha512-5QVOTXUdqTCjQuh2GGtdd7YEhoRXBMVGROAtsBeLGIbIz3obCBIfRMT1I3ZKkMgNzwkyCkftDXSSkHxnfVf4qg==
@@ -1989,6 +2004,15 @@
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.20.7":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.0.tgz#8c1f020c9df0e737e4e247c0619f58c68458aaeb"
+  integrity sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -2669,6 +2693,30 @@
     rc9 "^1.2.0"
     std-env "^2.3.0"
 
+"@nuxt/types@2.14.6":
+  version "2.14.6"
+  resolved "https://registry.yarnpkg.com/@nuxt/types/-/types-2.14.6.tgz#0b6626acdecf83ddf1d288272f8e97d7127ac2f0"
+  integrity sha512-wK2B71TkbNAWxIcxdaueMfSIubqQ1DK/Yzix1MbXMLp5JM+fQTPofU/o+PQ9cl1vESPmh79bV/PC/JHYC6xK3w==
+  dependencies:
+    "@types/autoprefixer" "^9.7.2"
+    "@types/babel__core" "^7.1.9"
+    "@types/compression" "^1.7.0"
+    "@types/connect" "^3.4.33"
+    "@types/etag" "^1.8.0"
+    "@types/file-loader" "^4.2.0"
+    "@types/html-minifier" "^4.0.0"
+    "@types/less" "^3.0.1"
+    "@types/node" "^12.12.62"
+    "@types/node-sass" "^4.11.1"
+    "@types/optimize-css-assets-webpack-plugin" "^5.0.1"
+    "@types/pug" "^2.0.4"
+    "@types/serve-static" "^1.13.5"
+    "@types/terser-webpack-plugin" "^2.2.0"
+    "@types/webpack" "^4.41.22"
+    "@types/webpack-bundle-analyzer" "^3.8.0"
+    "@types/webpack-dev-middleware" "^3.7.2"
+    "@types/webpack-hot-middleware" "^2.25.3"
+
 "@nuxt/typescript-build@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@nuxt/typescript-build/-/typescript-build-2.1.0.tgz#191fe60e942ce84a01468ba6e255744e01c7c538"
@@ -2781,16 +2829,16 @@
     webpack-node-externals "^3.0.0"
     webpackbar "^4.0.0"
 
-"@nuxtjs/axios@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/axios/-/axios-5.12.0.tgz#50692340e64ec838f167d292d59b1cc2a0e2dbef"
-  integrity sha512-VQI9Nnf12jWknldrgCNGzCQxnWO3/CvMwrkWKNUr3WtGYuOKryUOd1XXxDbaJmopfX4SGjKvDL1G6qTkWLiPew==
+"@nuxtjs/axios@5.13.6":
+  version "5.13.6"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/axios/-/axios-5.13.6.tgz#6f4bbd98a3a7799a5d2c0726c6ad2a98aa111881"
+  integrity sha512-XS+pOE0xsDODs1zAIbo95A0LKlilvJi8YW0NoXYuq3/jjxGgWDxizZ6Yx0AIIjZOoGsXJOPc0/BcnSEUQ2mFBA==
   dependencies:
-    "@nuxtjs/proxy" "^2.0.0"
-    axios "^0.19.2"
-    axios-retry "^3.1.8"
-    consola "^2.14.0"
-    defu "^2.0.4"
+    "@nuxtjs/proxy" "^2.1.0"
+    axios "^0.21.1"
+    axios-retry "^3.1.9"
+    consola "^2.15.3"
+    defu "^5.0.0"
 
 "@nuxtjs/eslint-config-typescript@6.0.1":
   version "6.0.1"
@@ -2815,7 +2863,7 @@
     eslint-plugin-unicorn "^28.0.2"
     eslint-plugin-vue "^7.9.0"
 
-"@nuxtjs/proxy@^2.0.0":
+"@nuxtjs/proxy@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/proxy/-/proxy-2.1.0.tgz#fa7715a11d237fa1273503c4e9e137dd1bf5575b"
   integrity sha512-/qtoeqXgZ4Mg6LRg/gDUZQrFpOlOdHrol/vQYMnKu3aN3bP90UfOUB3QSDghUUK7OISAJ0xp8Ld78aHyCTcKCQ==
@@ -2853,10 +2901,10 @@
   dependencies:
     lodash.debounce "4.0.8"
 
-"@rancher/shell@0.3.11":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-0.3.11.tgz#c3688454cad47a9dd097021f4e9002df79beaf53"
-  integrity sha512-lsHhk679ZssQuOBl6yVaRzBo0hVJP10u0Rr6b3lhu+HVJFGDA+p998uZ/mwznUZr++aOINb6xMKNxRs4V3T/Jw==
+"@rancher/shell@0.3.27":
+  version "0.3.27"
+  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-0.3.27.tgz#c22d640dec7f06504bb6c62dc27a9bda68049e60"
+  integrity sha512-/dI3yoG1JWhoywBg9t5iw9JHANvMgcZ8FerNJE5Mmt1NN/qYKlZLC8LtH2gVUJPaLtSYPx8laytZslU+jfPwZg==
   dependencies:
     "@aws-sdk/client-ec2" "3.1.0"
     "@aws-sdk/client-eks" "3.1.0"
@@ -2866,8 +2914,9 @@
     "@babel/preset-typescript" "7.16.7"
     "@innologica/vue-dropdown-menu" "0.1.3"
     "@novnc/novnc" "1.2.0"
+    "@nuxt/types" "2.14.6"
     "@nuxt/typescript-build" "2.1.0"
-    "@nuxtjs/axios" "5.12.0"
+    "@nuxtjs/axios" "5.13.6"
     "@nuxtjs/eslint-config-typescript" "6.0.1"
     "@nuxtjs/webpack-profile" "0.1.0"
     "@popperjs/core" "2.4.4"
@@ -2898,7 +2947,7 @@
     d3-selection "1.4.1"
     dagre-d3 "0.6.4"
     dayjs "1.8.29"
-    diff2html "2.11.2"
+    diff2html "3.4.24"
     dompurify "2.4.5"
     eslint "7.32.0"
     eslint-config-standard "16.0.3"
@@ -2935,10 +2984,7 @@
     nyc "15.1.0"
     papaparse "5.3.0"
     portal-vue "2.1.7"
-    rancher-icons rancher/icons#v2.0.14
-    require-extension-hooks "0.3.3"
-    require-extension-hooks-babel "1.0.0"
-    require-extension-hooks-vue "3.0.0"
+    rancher-icons rancher/icons#v2.0.16
     sass "1.51.0"
     sass-loader "10.2.1"
     serve-static "1.14.1"
@@ -3047,6 +3093,14 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/autoprefixer@^9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@types/autoprefixer/-/autoprefixer-9.7.2.tgz#64b3251c9675feef5a631b7dd34cfea50a8fdbcc"
+  integrity sha512-QX7U7YW3zX3ex6MECtWO9folTGsXeP4b8bSjTq3I1ODM+H+sFHwGKuof+T+qBcDClGlCGtDb3SVfiTVfmcxw4g==
+  dependencies:
+    "@types/browserslist" "*"
+    postcss "7.x.x"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.19"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.19.tgz#7b497495b7d1b4812bdb9d02804d0576f43ee460"
@@ -3054,6 +3108,17 @@
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__core@^7.1.9":
+  version "7.20.3"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.3.tgz#d5625a50b6f18244425a1359a858c73d70340778"
+  integrity sha512-54fjTSeSHwfan8AyHWrKbfBWiEUrNTZsUwPTDSNaaP1QDQIZbeNUg3a59E9D+375MzUw/x1vx2/0F5LBz+AeYA==
+  dependencies:
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
     "@types/babel__generator" "*"
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
@@ -3088,6 +3153,28 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/browserslist@*":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@types/browserslist/-/browserslist-4.15.0.tgz#ba0265b33003a2581df1fc5f483321a30205f2d2"
+  integrity sha512-h9LyKErRGZqMsHh9bd+FE8yCIal4S0DxKTOeui56VgVXqa66TKiuaIUxCAI7c1O0LjaUzOTcsMyOpO9GetozRA==
+  dependencies:
+    browserslist "*"
+
+"@types/clean-css@*":
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/@types/clean-css/-/clean-css-4.2.9.tgz#aa520e8483275ef824bb1b19d378cc6ca1c41350"
+  integrity sha512-pjzJ4n5eAXAz/L5Zur4ZymuJUvyo0Uh0iRnRI/1kADFLs76skDky0K0dX1rlv4iXXrJXNk3sxRWVJR7CMDroWA==
+  dependencies:
+    "@types/node" "*"
+    source-map "^0.6.0"
+
+"@types/compression@^1.7.0":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-1.7.4.tgz#c1af4a0f2d72ea6c96300ae58b9842aa87d77b6e"
+  integrity sha512-sdFVnQJRkQBX83ydsLCBm4A39p45y0QkxdAR689yOtAFNbbS9Acrp86RZWJj6BHRXyZH9tX4t1dU7XDiGdY3nA==
+  dependencies:
+    "@types/express" "*"
+
 "@types/connect-history-api-fallback@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
@@ -3103,10 +3190,24 @@
   dependencies:
     "@types/node" "*"
 
+"@types/connect@^3.4.33":
+  version "3.4.37"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.37.tgz#c66a96689fd3127c8772eb3e9e5c6028ec1a9af5"
+  integrity sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cookie@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
   integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
+"@types/etag@^1.8.0":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@types/etag/-/etag-1.8.2.tgz#c5714da83dcd0dd51f25e527daf36d0df051ea6c"
+  integrity sha512-z8Pbo2e+EZWMpuRPYSjhSivp2OEkqrMZBUfEAWlJC31WUCKveZ8ioWXHAC5BXRZfwxCBfYRhPij1YJHK1W6oDA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
   version "4.17.31"
@@ -3127,6 +3228,13 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/file-loader@^4.2.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/file-loader/-/file-loader-4.2.1.tgz#f41154dc90d578002df8ae94db80c315e844720e"
+  integrity sha512-ImtIwnIEEMgyE7DK1JduhiDv+8WzfRWb3BPuf6RiBD1ySz05vyDRhGiKvIcuUPxUzMNBRZHN0pB+bWXSX3+t1w==
+  dependencies:
+    "@types/webpack" "^4"
+
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -3146,6 +3254,20 @@
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
   integrity sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==
+
+"@types/html-minifier@^4.0.0":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/html-minifier/-/html-minifier-4.0.4.tgz#4d8501885918af2f74d9fbfb86acabca44af7306"
+  integrity sha512-kvzPbhN6CM+zFdOmLaGKF1DUnn9oYZteTiltHRFhsnj3vcnCZj1qVA0x1E7FTZvLT8e4WsHTSXk/0YV2NgOWOw==
+  dependencies:
+    "@types/clean-css" "*"
+    "@types/relateurl" "*"
+    "@types/uglify-js" "*"
+
+"@types/http-errors@*":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.3.tgz#c54e61f79b3947d040f150abd58f71efb422ff62"
+  integrity sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA==
 
 "@types/http-proxy@^1.17.5":
   version "1.17.9"
@@ -3183,10 +3305,22 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/less@^3.0.1":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/less/-/less-3.0.5.tgz#8b219a7af34d4356934d5cdb31d5ed184b2766cc"
+  integrity sha512-OdhItUN0/Cx9+sWumdb3dxASoA0yStnZahvKcaSQmSR5qd7hZ6zhSriSQGUU3F8GkzFpIILKzut4xn9/GvhusA==
+
 "@types/lodash@4.14.184":
   version "4.14.184"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.184.tgz#23f96cd2a21a28e106dc24d825d4aa966de7a9fe"
   integrity sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==
+
+"@types/memory-fs@*":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@types/memory-fs/-/memory-fs-0.3.6.tgz#8f70d74727e924dc46f0ede8b20da8c1e862d075"
+  integrity sha512-8FJJIEYozFz8GpRotYXcqQ33RhRS+SgvWlPFUsS8e0vEsjHhFHptI/VHr/41qnw/fLsgWS6UlyqP2PUXcj68eQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/mime@*":
   version "3.0.1"
@@ -3203,6 +3337,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/node-sass@^4.11.1":
+  version "4.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node-sass/-/node-sass-4.11.6.tgz#adb2f6e5486230049c4651de69709b3f16065ab1"
+  integrity sha512-Qkf5Fs9zzsXchenUY7oVdIHyv8FtPgqIXqOJzhh3FDqpYjqvc/gtZ3hlZVFmKQhl7wyI4+WkRbYufYC5pfY7iw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "18.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.0.tgz#f38c7139247a1d619f6cc6f27b072606af7c289d"
@@ -3212,6 +3353,11 @@
   version "16.4.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.3.tgz#c01c1a215721f6dec71b47d88b4687463601ba48"
   integrity sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==
+
+"@types/node@^12.12.62":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
 "@types/node@^14.14.31":
   version "14.18.32"
@@ -3223,6 +3369,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/optimize-css-assets-webpack-plugin@^5.0.1":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@types/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.7.tgz#56c9418ada90d3c38e43f338c8b20a85e087e45a"
+  integrity sha512-LcYr4KifgRzN4fdKvPlPWYvrKJdLUey1Qq1DUvyhaV8DVrEsTxCKGLeocPrxinzlehC0Z30U9Ea9Dc1cd0FmUg==
+  dependencies:
+    "@types/webpack" "^4"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -3232,6 +3385,11 @@
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
   integrity sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==
+
+"@types/pug@^2.0.4":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.8.tgz#1a85ecb760f7472d9ec3bab19bfe17454c69499d"
+  integrity sha512-QzhsZ1dMGyJbn/D9V80zp4GIA4J4rfAjCCxc3MP+new0E8dyVdSkR735Lx+n3LIaHNFcjHL5+TbziccuT+fdoQ==
 
 "@types/q@^1.5.1":
   version "1.5.5"
@@ -3248,11 +3406,25 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/relateurl@*":
+  version "0.2.31"
+  resolved "https://registry.yarnpkg.com/@types/relateurl/-/relateurl-0.2.31.tgz#7b1efc6f9b22847663d1bff61825e2a39dcd1d5f"
+  integrity sha512-vpqphbm0l/+6qWraFPDB2dq+vkJYFHKSdogLaOqdqjLZ6v4q/0HEBv3HGeEVlCdWXo8HEdAzA2vBNk7ZRXo2Cw==
+
 "@types/serve-static@*":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
   integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
   dependencies:
+    "@types/mime" "*"
+    "@types/node" "*"
+
+"@types/serve-static@^1.13.5":
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.4.tgz#44b5895a68ca637f06c229119e1c774ca88f81b2"
+  integrity sha512-aqqNfs1XTF0HDrFdlY//+SGUxmdSUbjeRXb5iaZc3x0/vMbYmdw9qvOgHWOyyLFxSSRnUuP5+724zBgfw8/WAw==
+  dependencies:
+    "@types/http-errors" "*"
     "@types/mime" "*"
     "@types/node" "*"
 
@@ -3281,12 +3453,37 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
 
+"@types/terser-webpack-plugin@^2.2.0":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@types/terser-webpack-plugin/-/terser-webpack-plugin-2.2.3.tgz#53ee74f6c237843ddf98ac409c250226412db85b"
+  integrity sha512-IqmP1OBzNyx9ZNj/3Svf0QFN+cJUrtECceVLENlXhXX4snmkgxo8n3U3wMJv1c066FXqwP+iorzCZCJhshytsw==
+  dependencies:
+    "@types/webpack" "^4"
+    terser "^4.3.9"
+
 "@types/uglify-js@*":
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.17.0.tgz#95271e7abe0bf7094c60284f76ee43232aef43b9"
   integrity sha512-3HO6rm0y+/cqvOyA8xcYLweF0TKXlAxmQASjbOi49Co51A1N4nR4bEwBgRoD9kNM+rqFGArjKr654SLp2CoGmQ==
   dependencies:
     source-map "^0.6.1"
+
+"@types/webpack-bundle-analyzer@^3.8.0":
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.7.tgz#1f6e8810e77fe9e590db697590da7536ebd560f6"
+  integrity sha512-TxVRBSE5W5zb6q+MqdfAduWT0Fc6SoxdvnxUJrtbrMrVGjVQCLagwLbRByU9Jyy99v319wVunaFt/GmUiDDeGg==
+  dependencies:
+    "@types/webpack" "^4"
+
+"@types/webpack-dev-middleware@^3.7.2":
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/@types/webpack-dev-middleware/-/webpack-dev-middleware-3.7.5.tgz#a5e87668d36b3e8cf2c58a9e27314b7cf0999fce"
+  integrity sha512-jHcCoRc2Hh6oDozoc27ibKAqrfn8nlewheoFV704EMJqheaOe7HxZZp9Q39bPh2eUDLtEJApLNQy6l20yT/4jA==
+  dependencies:
+    "@types/connect" "*"
+    "@types/memory-fs" "*"
+    "@types/webpack" "^4"
+    loglevel "^1.6.2"
 
 "@types/webpack-dev-server@^3.11.0":
   version "3.11.6"
@@ -3304,6 +3501,15 @@
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.0.tgz#ed6ecaa8e5ed5dfe8b2b3d00181702c9925f13fb"
   integrity sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==
 
+"@types/webpack-hot-middleware@^2.25.3":
+  version "2.25.8"
+  resolved "https://registry.yarnpkg.com/@types/webpack-hot-middleware/-/webpack-hot-middleware-2.25.8.tgz#e76a84b6a0146f7bdb4ed4d0d1f75078828d4b72"
+  integrity sha512-I3DcpYoXvWsX77WhgWbnVJw9FrxOOv7pqKHAxB8FKh6e6H6fcyeBT4vyrDqpPDim+EM1TY0oY7j8Ls3ResMKcA==
+  dependencies:
+    "@types/connect" "*"
+    tapable "^2.2.0"
+    webpack "^5"
+
 "@types/webpack-sources@*":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
@@ -3317,6 +3523,18 @@
   version "4.41.33"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.33.tgz#16164845a5be6a306bcbe554a8e67f9cac215ffc"
   integrity sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^1"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    anymatch "^3.0.0"
+    source-map "^0.6.0"
+
+"@types/webpack@^4.41.22":
+  version "4.41.35"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.35.tgz#32903809685caf87ea612e4e74577874359c3749"
+  integrity sha512-XRC6HLGHtNfN8/xWeu1YUQV1GSE+28q8lSqvcJ+0xt/zW9Wmn4j9pCSvaXPyRlCKrl5OuqECQNEJUy2vo8oWqg==
   dependencies:
     "@types/node" "*"
     "@types/tapable" "^1"
@@ -3682,21 +3900,6 @@
     "@babel/parser" "^7.18.4"
     postcss "^8.4.14"
     source-map "^0.6.1"
-
-"@vue/component-compiler-utils@^2.3.1":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz#aa46d2a6f7647440b0b8932434d22f12371e543b"
-  integrity sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==
-  dependencies:
-    consolidate "^0.15.1"
-    hash-sum "^1.0.2"
-    lru-cache "^4.1.2"
-    merge-source-map "^1.1.0"
-    postcss "^7.0.14"
-    postcss-selector-parser "^5.0.0"
-    prettier "1.16.3"
-    source-map "~0.6.1"
-    vue-template-es2015-compiler "^1.9.0"
 
 "@vue/component-compiler-utils@^3.1.0", "@vue/component-compiler-utils@^3.1.2":
   version "3.3.0"
@@ -4355,20 +4558,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios-retry@^3.1.8:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.3.1.tgz#47624646138aedefbad2ac32f226f4ee94b6dcab"
-  integrity sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==
+axios-retry@^3.1.9:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.8.1.tgz#4bb53f87ea537bce904c477e5c2808571066acbb"
+  integrity sha512-4XseuArB4CEbfLRtMpUods2q8MLBvD4r8ifKgK4SP2FRgzQIPUDpzZ+cjQ/19eu3w2UpKgkJA+myEh2BYDSjqQ==
   dependencies:
     "@babel/runtime" "^7.15.4"
     is-retry-allowed "^2.2.0"
-
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
 
 axios@^0.21.1:
   version "0.21.4"
@@ -4831,6 +5027,16 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@*:
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.1.tgz#ba91958d1a59b87dab6fed8dfbcb3da5e2e9c619"
+  integrity sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==
+  dependencies:
+    caniuse-lite "^1.0.30001541"
+    electron-to-chromium "^1.4.535"
+    node-releases "^2.0.13"
+    update-browserslist-db "^1.0.13"
+
 browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.21.3, browserslist@^4.21.4, browserslist@^4.6.4:
   version "4.21.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
@@ -5086,6 +5292,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, can
   version "1.0.30001421"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001421.tgz#979993aaacff5ab72a8d0d58c28ddbcb7b4deba6"
   integrity sha512-Sw4eLbgUJAEhjLs1Fa+mk45sidp1wRn5y6GtDpHGBaNJ9OCDJaVh2tIaWWUnGfuXfKf1JCBaIarak3FkVAvEeA==
+
+caniuse-lite@^1.0.30001541:
+  version "1.0.30001558"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001558.tgz#d2c6e21fdbfe83817f70feab902421a19b7983ee"
+  integrity sha512-/Et7DwLqpjS47JPEcz6VnxU9PwcIdVi0ciLXRWBQdj1XFye68pSQYpV0QtPTfUKWuOaEig+/Vez2l74eDc1tPQ==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -5568,7 +5779,7 @@ connect@^3.7.0:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
-consola@^2.10.0, consola@^2.14.0, consola@^2.15.0, consola@^2.15.3, consola@^2.6.0, consola@^2.9.0:
+consola@^2.10.0, consola@^2.15.0, consola@^2.15.3, consola@^2.6.0, consola@^2.9.0:
   version "2.15.3"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
   integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
@@ -5609,7 +5820,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@^1.3.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
@@ -5960,14 +6171,6 @@ css-select@^4.1.3:
     domhandler "^4.3.1"
     domutils "^2.8.0"
     nth-check "^2.0.1"
-
-css-selector-tokenizer@^0.7.0:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz#735f26186e67c749aaf275783405cf0661fae8f1"
-  integrity sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==
-  dependencies:
-    cssesc "^3.0.0"
-    fastparse "^1.1.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -6769,13 +6972,6 @@ debug@4.3.2:
   dependencies:
     ms "2.1.2"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.1.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -6889,11 +7085,6 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-defu@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/defu/-/defu-2.0.4.tgz#09659a6e87a8fd7178be13bd43e9357ebf6d1c46"
-  integrity sha512-G9pEH1UUMxShy6syWk01VQSRVs3CDWtlxtZu7A+NyqjxaCA4gSlWAKDBx6QiUEKezqS8+DUlXLI14Fp05Hmpwg==
-
 defu@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/defu/-/defu-4.0.1.tgz#9d7d7a48f9295f08285d153dcff174c89b9bcb22"
@@ -7002,15 +7193,20 @@ diff-sequences@^27.5.1:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
   integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
-diff2html@2.11.2:
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-2.11.2.tgz#f3f27c6b81a75b5a8a3cfb7ae2fda2127290c809"
-  integrity sha512-FKDFFXW0cHyt+joiYeyWxbcLWZsQYeYRRrHKWZEvu+XMFMM1ChxTkGhET53zAU0tvVjyRRxRjUcrn5ImSqD0ZQ==
+diff2html@3.4.24:
+  version "3.4.24"
+  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.24.tgz#42811f1830fa12b9ad73baebcf63431b20c2445d"
+  integrity sha512-eVzxAj8r52nm5QLVCVlVD/J0VR4X9vVLkgkdI7w7b5cw81pyYxgqed9WetjBwjYXzprdkOcmILKK3qzWg/ld3A==
   dependencies:
-    diff "^4.0.1"
-    hogan.js "^3.0.2"
-    merge "^1.2.1"
-    whatwg-fetch "^3.0.0"
+    diff "5.1.0"
+    hogan.js "3.0.2"
+  optionalDependencies:
+    highlight.js "11.6.0"
+
+diff@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
@@ -7243,6 +7439,11 @@ electron-to-chromium@^1.4.251:
   version "1.4.284"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
+
+electron-to-chromium@^1.4.535:
+  version "1.4.569"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.569.tgz#1298b67727187ffbaac005a7425490d157f3ad03"
+  integrity sha512-LsrJjZ0IbVy12ApW3gpYpcmHS3iRxH4bkKOW98y1/D+3cvDUWGcbzbsFinfUS8knpcZk/PG/2p/RnkMCYN7PVg==
 
 element-matches@^0.1.2:
   version "0.1.2"
@@ -8178,11 +8379,6 @@ fast-xml-parser@^3.16.0:
   dependencies:
     strnum "^1.0.4"
 
-fastparse@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
-  integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
-
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
@@ -8382,13 +8578,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.15.2"
@@ -8629,13 +8818,6 @@ functions-have-names@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
-
-generic-names@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-1.0.3.tgz#2d786a121aee508876796939e8e3bff836c20917"
-  integrity sha512-b6OHfQuKasIKM9b6YPkX+KUj/TLBTx3B/1aT1T5F12FEuEqyFMdr59OMS53aoaSw8eVtapdqieX6lbg5opaOhA==
-  dependencies:
-    loader-utils "^0.2.16"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -8938,11 +9120,6 @@ has-bigints@^1.0.1, has-bigints@^1.0.2:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
 
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-  integrity sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -9055,6 +9232,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highlight.js@11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.6.0.tgz#a50e9da05763f1bb0c1322c8f4f755242cff3f5a"
+  integrity sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==
+
 highlight.js@^10.7.1:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
@@ -9069,7 +9251,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hogan.js@^3.0.2:
+hogan.js@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
   integrity sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==
@@ -9369,11 +9551,6 @@ iconv-lite@0.6:
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
-
-icss-replace-symbols@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
-  integrity sha512-chIaY3Vh2mh2Q3RGXttaDIzeiPvaVXJ+C4DAh/w3c37SKZ/U6PGMmuicR2EQQp9bKG8zLMCl7I+PtIoOOPp8Gg==
 
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
@@ -10564,11 +10741,6 @@ jquery@3.5.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
-js-base64@^2.1.9:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
-  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
-
 js-beautify@^1.6.12:
   version "1.14.6"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.14.6.tgz#b23ca5d74a462c282c7711bb51150bcc97f2b507"
@@ -11135,6 +11307,11 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+loglevel@^1.6.2:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
+  integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==
+
 loglevel@^1.6.8:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
@@ -11325,7 +11502,7 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
 
-merge-source-map@^1.0.3, merge-source-map@^1.1.0:
+merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
   integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
@@ -11341,11 +11518,6 @@ merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
-merge@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -11763,6 +11935,11 @@ node-preload@^0.2.1:
   integrity sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==
   dependencies:
     process-on-spawn "^1.0.0"
+
+node-releases@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
+  integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
 
 node-releases@^2.0.6:
   version "2.0.6"
@@ -12945,14 +13122,6 @@ postcss-modules-extract-imports@^3.0.0:
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
   integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
 
-postcss-modules-local-by-default@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
-  integrity sha512-X4cquUPIaAd86raVrBwO8fwRfkIdbwFu7CTfEOjiZQHVQwlHRSkTgH5NLDmMm5+1hQO8u6dZ+TOOJDbay1hYpA==
-  dependencies:
-    css-selector-tokenizer "^0.7.0"
-    postcss "^6.0.1"
-
 postcss-modules-local-by-default@^3.0.2, postcss-modules-local-by-default@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz#bb14e0cc78279d504dbdcbfd7e0ca28993ffbbb0"
@@ -12972,14 +13141,6 @@ postcss-modules-local-by-default@^4.0.0:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
-postcss-modules-scope@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz#d6ea64994c79f97b62a72b426fbe6056a194bb90"
-  integrity sha512-LTYwnA4C1He1BKZXIx1CYiHixdSe9LWYVKadq9lK5aCCMkoOkFyZ7aigt+srfjlRplJY3gIol6KUNefdMQJdlw==
-  dependencies:
-    css-selector-tokenizer "^0.7.0"
-    postcss "^6.0.1"
-
 postcss-modules-scope@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz#385cae013cc7743f5a7d7602d1073a89eaae62ee"
@@ -12994,18 +13155,6 @@ postcss-modules-scope@^3.0.0:
   integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
   dependencies:
     postcss-selector-parser "^6.0.4"
-
-postcss-modules-sync@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-sync/-/postcss-modules-sync-1.0.0.tgz#619a719cf78dd16a4834135140b324cf77334be1"
-  integrity sha512-kIDk2NYmxHshqUbjtFf1WdBij08IsvRdgDT0nOGWhvwkr8/z1piLSzxVrPt56J4DU6ON986h2H+5xcBnFhT8UQ==
-  dependencies:
-    generic-names "^1.0.2"
-    icss-replace-symbols "^1.0.2"
-    postcss "^5.2.5"
-    postcss-modules-local-by-default "^1.1.1"
-    postcss-modules-scope "^1.0.2"
-    string-hash "^1.1.0"
 
 postcss-modules-values@^3.0.0:
   version "3.0.0"
@@ -13244,7 +13393,7 @@ postcss-selector-parser@^3.0.0:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^5.0.0, postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
+postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
   integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
@@ -13325,26 +13474,7 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^5.2.5:
-  version "5.2.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
-  integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
-  dependencies:
-    chalk "^1.1.3"
-    js-base64 "^2.1.9"
-    source-map "^0.5.6"
-    supports-color "^3.2.3"
-
-postcss@^6.0.1:
-  version "6.0.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
-  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
-  dependencies:
-    chalk "^2.4.1"
-    source-map "^0.6.1"
-    supports-color "^5.4.0"
-
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0.5, postcss@^7.0.6:
+postcss@7.x.x, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.39"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
   integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
@@ -13384,11 +13514,6 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==
-
-prettier@1.16.3:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.3.tgz#8c62168453badef702f34b45b6ee899574a6a65d"
-  integrity sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==
 
 "prettier@^1.18.2 || ^2.0.0":
   version "2.7.1"
@@ -13627,9 +13752,9 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-rancher-icons@rancher/icons#v2.0.14:
-  version "2.0.14"
-  resolved "https://codeload.github.com/rancher/icons/tar.gz/9d31e6c3dfe99493207e6bbfa957551da476735f"
+rancher-icons@rancher/icons#v2.0.16:
+  version "2.0.16"
+  resolved "https://codeload.github.com/rancher/icons/tar.gz/fc788547982a7800030fe37ad0b40747bec24b1f"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
@@ -13939,36 +14064,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
-
-require-extension-hooks-babel@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/require-extension-hooks-babel/-/require-extension-hooks-babel-1.0.0.tgz#78755c505ab884077d51fc393bfc3b2884249777"
-  integrity sha512-n8+KxBVMjUgNz3ipFOrGoflWgiabcoGul8PE+5JZk1oA3/Bb5jtCvne/sRZ4TjkFuqDDOiWxPfAVK/UsL0iMOw==
-  dependencies:
-    "@babel/core" "^7.4.4"
-    "@babel/preset-env" "^7.4.4"
-
-require-extension-hooks-vue@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/require-extension-hooks-vue/-/require-extension-hooks-vue-3.0.0.tgz#09126a5ef7db5cd25c21346b848ed95e6e5cb615"
-  integrity sha512-vxjepJ6JOvpplt1wjLZH7hcyW6I7hKGdCI5Btr5kr/7hr/8WP9Qqojy/kgtlIN6KUMkPKpjAmx1VRmcuaH+abQ==
-  dependencies:
-    "@vue/component-compiler-utils" "^2.3.1"
-    consolidate "^0.15.1"
-    postcss "^7.0.14"
-    postcss-modules-sync "^1.0.0"
-    source-map-support "^0.5.10"
-
-require-extension-hooks@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/require-extension-hooks/-/require-extension-hooks-0.3.3.tgz#e5a4eb1c821bf70b84a7e8374e3c4166dc42a820"
-  integrity sha512-UrOSBIFHu2D1pVyeCl3+5/FBE4aTgoxyYu5iDR0BhtwRsdSzNzrKAvQGUlbELj1LgjI0HNWLUaOpns+iZpw3eQ==
-  dependencies:
-    convert-source-map "^1.3.0"
-    merge-source-map "^1.0.3"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    source-map "^0.5.6"
 
 require-from-string@^2.0.2:
   version "2.0.2"
@@ -14699,7 +14794,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.10, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.20:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -14950,11 +15045,6 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
 
-string-hash@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
-  integrity sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -15101,14 +15191,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==
 
-supports-color@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==
-  dependencies:
-    has-flag "^1.0.0"
-
-supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -15194,6 +15277,11 @@ tapable@^1.0.0, tapable@^1.0.0-beta.5, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
 tar@^6.0.2:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
@@ -15244,7 +15332,7 @@ terser-webpack-plugin@^4.2.3:
     terser "^5.3.4"
     webpack-sources "^1.4.3"
 
-terser@^4.1.2, terser@^4.6.3:
+terser@^4.1.2, terser@^4.3.9, terser@^4.6.3:
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.1.tgz#a00e5634562de2239fd404c649051bf6fc21144f"
   integrity sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==
@@ -15825,6 +15913,14 @@ upath@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
   integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
+
+update-browserslist-db@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
+  integrity sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
 
 update-browserslist-db@^1.0.9:
   version "1.0.10"
@@ -16462,7 +16558,7 @@ webpack-virtual-modules@0.4.3:
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.3.tgz#cd597c6d51d5a5ecb473eea1983a58fa8a17ded9"
   integrity sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==
 
-webpack@4, webpack@^4.0.0, webpack@^4.46.0:
+webpack@4, webpack@^4.0.0, webpack@^4.46.0, webpack@^5:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
@@ -16525,11 +16621,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@^3.0.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Fixes #139 

- Use `v-clean-html` instead of `v-html`
- Bump shell version used to `0.3.27`
- Breakdown of `pkg/elemental/pages/index.vue` main view into components such as `DashboardView` and `InstallView`
- Create `InstallView` which enables user to install Elemental Operator from Rancher Marketplace

**To test:**
- You will need to have Rancher backend version `2.8.0` (2.8-head, 2.8.0-rc3, etc)
- Make sure you don't have already installed elemental operator
- Run this branch and go to elemental extension and follow the steps

**Preview:**
https://github.com/rancher/elemental-ui/assets/97888974/6b8781de-80ea-4b92-8d82-14994869ea8c

