### PR TITLE
Update groups creation form does not clear data when switching from 'Managed OS Version' to 'Use image from registry'

### DIFF
--- a/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
@@ -132,6 +132,16 @@ export default {
     },
     handleManagedOSVersionNameChange(ev) {
       this.value.spec.managedOSVersionName = ev.split(STRING_SEPARATOR)[1];
+    },
+    handleRadioBtnChange(val) {
+      // if TRUE, this mean we are on option "use managed OS version"
+      // so we should clear the "image path" (OS image) field
+      if (val) {
+        delete this.value?.spec?.osImage;
+      } else {
+        delete this.value?.spec?.managedOSVersionName;
+        this.osVersionSelected = '';
+      }
     }
   },
 };
@@ -178,6 +188,7 @@ export default {
           :options="[true, false]"
           :labels="[t('elemental.osimage.create.radioOptions.osImages'), t('elemental.osimage.create.radioOptions.registry')]"
           :mode="mode"
+          @input="handleRadioBtnChange($event)"
         />
         <div v-if="useManagedOsImages">
           <LabeledSelect


### PR DESCRIPTION
Fixes #153 

- fix issue where data was not being cleared properly when selecting options on radio group

**Before**

https://github.com/rancher/elemental-ui/assets/97888974/0f472b7d-9e84-4706-b3ab-3a436e05506c

**After**

https://github.com/rancher/elemental-ui/assets/97888974/543bc591-0e5d-46a3-bb50-8e6ee6e73c2d

