### PR TITLE
revert changes to build media type

### DIFF
--- a/pkg/elemental/components/BuildMedia.vue
+++ b/pkg/elemental/components/BuildMedia.vue
@@ -6,7 +6,6 @@ import { randomStr, CHARSET } from '@shell/utils/string';
 import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
 
 const MEDIA_TYPES = {
-
   RAW: {
     filterType: 'container',
     type:       'raw',
@@ -44,6 +43,16 @@ export default {
   async fetch() {
     this.seedImagesList = await this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.SEED_IMAGE });
     this.managedOsVersions = await this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSIONS });
+
+    // *********** TO DELETE WHEN MEDIA TYPE IS GOOD TO GO
+    this.filteredManagedOsVersions = this.managedOsVersions.filter(v => v.spec?.type === MEDIA_TYPES.ISO.type) || [];
+    this.buildMediaOsVersions = this.filteredManagedOsVersions.map((f) => {
+      return {
+        label: `${ f.spec?.metadata?.displayName } ${ f.spec?.version }`,
+        value: f.spec?.metadata?.uri,
+      };
+    });
+    // EO DELETE!!!
   },
   data() {
     return {
@@ -55,7 +64,9 @@ export default {
         { label: MEDIA_TYPES.ISO.label, value: MEDIA_TYPES.ISO.type },
         { label: MEDIA_TYPES.RAW.label, value: MEDIA_TYPES.RAW.type },
       ],
-      buildMediaTypeSelected:       '',
+      // *********** TO UNCOMMENT WHEN MEDIA TYPE IS GOOD TO GO
+      // buildMediaTypeSelected:       '',
+      buildMediaTypeSelected:       MEDIA_TYPES.ISO,
       buildMediaOsVersionSelected:  '',
       registrationEndpointSelected: '',
       mediaBuildTriggerError:       '',
@@ -92,10 +103,14 @@ export default {
     },
     isBuildMediaBtnEnabled() {
       if (this.displayRegEndpoints) {
-        return this.registrationEndpointSelected && this.buildMediaOsVersionSelected && this.buildMediaTypeSelected;
+        // *********** TO UNCOMMENT WHEN MEDIA TYPE IS GOOD TO GO
+        // return this.registrationEndpointSelected && this.buildMediaOsVersionSelected && this.buildMediaTypeSelected;
+        return this.registrationEndpointSelected && this.buildMediaOsVersionSelected;
       }
 
-      return this.buildMediaOsVersionSelected && this.buildMediaTypeSelected;
+      // *********** TO UNCOMMENT WHEN MEDIA TYPE IS GOOD TO GO
+      // return this.buildMediaOsVersionSelected && this.buildMediaTypeSelected;
+      return this.buildMediaOsVersionSelected;
     },
     seedImageFound() {
       if (this.seedImage) {
@@ -153,7 +168,8 @@ export default {
           namespace: 'fleet-default'
         },
         spec: {
-          type:            this.buildMediaTypeSelected,
+          // *********** TO UNCOMMENT WHEN MEDIA TYPE IS GOOD TO GO
+          // type:            this.buildMediaTypeSelected,
           baseImage:       this.buildMediaOsVersionSelected,
           registrationRef: {
             name:      machineRegName,
@@ -208,7 +224,8 @@ export default {
           :options="registrationEndpointsOptions"
         />
       </div>
-      <div class="col span-2">
+      <!-- *********** TO UNCOMMENT WHEN MEDIA TYPE IS GOOD TO GO -->
+      <!-- <div class="col span-2">
         <LabeledSelect
           v-model="buildMediaTypeSelected"
           class="mr-20"
@@ -218,7 +235,7 @@ export default {
           :options="buildMediaTypes"
           option-key="value"
         />
-      </div>
+      </div> -->
       <div class="col span-3">
         <LabeledSelect
           v-model="buildMediaOsVersionSelected"


### PR DESCRIPTION
Hide "build media type" select from the UI since the newest operator version about to be released won't include it yet

**Before**
![Screenshot 2024-01-24 at 15 06 02](https://github.com/rancher/elemental-ui/assets/97888974/f0393a42-da9a-4cfb-aea4-88f1c6550b6f)

**After**
![Screenshot 2024-01-24 at 15 01 30](https://github.com/rancher/elemental-ui/assets/97888974/dad20df3-d993-4bb8-bbb0-524d0227ec09)
