### PR TITLE
revert machine count update

### DIFF
--- a/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
+++ b/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
@@ -106,10 +106,6 @@ export default {
         isNone:  matched === 0,
         sample,
       };
-
-      // emit matched machine inventories on selector so that machine count
-      // on machine pool can be kept up to date
-      this.$emit('updateMachineCount', matched);
     }, 250, { leading: true })
   },
 };


### PR DESCRIPTION
Fixes #162 

- Remove `emit` that triggered `Machine Count` to be the same number as "Machine Inventories" that matched the selector template. 

<img width="1788" alt="Screenshot 2024-02-16 at 12 30 21" src="https://github.com/rancher/elemental-ui/assets/97888974/a3727380-d897-4977-9706-8deb08befe04">
