### PR TITLE
Include btrfs snapshotter in UI defaults

### DIFF
--- a/pkg/elemental/models/elemental.cattle.io.machineregistration.js
+++ b/pkg/elemental/models/elemental.cattle.io.machineregistration.js
@@ -15,8 +15,12 @@ const DEFAULT_CREATION_YAML = `config:
       passwd: root
   elemental:
     install:
-      poweroff: true
-      device: /dev/nvme0n1`;
+      reboot: true
+      device: /dev/nvme0n1
+      snapshotter:
+        type: btrfs
+    reset:
+      enabled: true`;
 
 export default class MachineRegistration extends ElementalResource {
   applyDefaults(vm, mode) {

--- a/pkg/elemental/models/elemental.cattle.io.machineregistration.js
+++ b/pkg/elemental/models/elemental.cattle.io.machineregistration.js
@@ -16,11 +16,19 @@ const DEFAULT_CREATION_YAML = `config:
   elemental:
     install:
       reboot: true
-      device: /dev/nvme0n1
+      device-selector:
+      - key: Name
+        operator: In
+        values:
+        - /dev/sda
+        - /dev/vda
+        - /dev/nvme0
+      - key: Size
+        operator: Gt
+        values:
+        - 25Gi
       snapshotter:
-        type: btrfs
-    reset:
-      enabled: true`;
+        type: btrfs`;
 
 export default class MachineRegistration extends ElementalResource {
   applyDefaults(vm, mode) {


### PR DESCRIPTION
In addition this commit also changes few other defaults such as `reboot: true` instead of `poweroff` and also enables reset.

This makes it easier to test and experiment elemental when quickly trying it out from the UI.

Part of rancher/elemental#1241