### PR TITLE
working on feature versioning mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "css-loader": "4.3.0"
   },
   "devDependencies": {
-    "@types/node": "18.11.9"
+    "@types/node": "18.11.9",
+    "@types/semver": "^7.5.8",
+    "semver": "^7.6.0"
   },
   "scripts": {
     "dev": "NODE_ENV=dev ./node_modules/.bin/vue-cli-service serve",

--- a/pkg/elemental/components/BuildMedia.vue
+++ b/pkg/elemental/components/BuildMedia.vue
@@ -4,7 +4,7 @@ import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
 import { randomStr, CHARSET } from '@shell/utils/string';
 import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
-import { semverVersionCheck, getOperatorVersion, getGatedFeatures, BUILD_MEDIA_RAW_SUPPORT } from '../utils/feature-versioning';
+import { semverVersionCheck, getOperatorVersion, getGatedFeature, BUILD_MEDIA_RAW_SUPPORT } from '../utils/feature-versioning';
 
 const MEDIA_TYPES = {
   RAW: {
@@ -54,8 +54,8 @@ export default {
     this.managedOsVersions = await this.$store.dispatch('management/findAll', { type: ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSIONS });
 
     this.operatorVersion = await getOperatorVersion(this.$store);
-    this.gatedFeatures = getGatedFeatures(this.resource, this.mode, BUILD_MEDIA_RAW_SUPPORT);
-    this.buildMediaGatingVersion = this.gatedFeatures?.[0]?.minOperatorVersion || '';
+    this.gatedFeature = getGatedFeature(this.resource, this.mode, BUILD_MEDIA_RAW_SUPPORT);
+    this.buildMediaGatingVersion = this.gatedFeature?.minOperatorVersion || '';
   },
   data() {
     return {
@@ -63,7 +63,7 @@ export default {
       managedOsVersions:            [],
       filteredManagedOsVersions:    [],
       operatorVersion:              '',
-      gatedFeatures:                [],
+      gatedFeature:                 {},
       buildMediaGatingVersion:      '',
       buildMediaOsVersions:         [],
       buildMediaTypes:              [

--- a/pkg/elemental/components/DashboardView.vue
+++ b/pkg/elemental/components/DashboardView.vue
@@ -1,6 +1,7 @@
 <script>
 import { allHash } from '@shell/utils/promise';
 import { CAPI, CATALOG } from '@shell/config/types';
+import { _VIEW } from '@shell/config/query-params';
 import { NAME } from '@shell/config/table-headers';
 import ResourceTable from '@shell/components/ResourceTable';
 import PercentageBar from '@shell/components/PercentageBar';
@@ -10,6 +11,7 @@ import {
   ELEMENTAL_CLUSTER_PROVIDER,
   KIND
 } from '../config/elemental-types';
+import { ELEMENTAL_TYPES } from '../types';
 import { createElementalRoute } from '../utils/custom-routing';
 import { filterForElementalClusters } from '../utils/elemental-utils';
 import BuildMedia from './BuildMedia';
@@ -54,7 +56,7 @@ export default {
     // we need to check for the length of the response
     // due to some issue with a standard-user, which can list apps
     // but the list comes up empty []
-    const isElementalOperatorNotInstalledOnApps = allDispatches.installedApps && allDispatches.installedApps.length && !allDispatches.installedApps.find(item => item.id.includes('elemental-operator'));
+    const isElementalOperatorNotInstalledOnApps = allDispatches.installedApps && allDispatches.installedApps.length && !allDispatches.installedApps.find(item => item.id.includes('elemental-operator') && !item.id.includes('elemental-operator-crds'));
 
     // check if CRD is there but operator isn't
     if (allDispatches.elementalSchema && isElementalOperatorNotInstalledOnApps) {
@@ -65,6 +67,8 @@ export default {
     return {
       ELEMENTAL_CLUSTERS:                    'elementalClusters',
       isElementalOpNotInstalledAndHasSchema: false,
+      resource:                              ELEMENTAL_TYPES.DASHBOARD,
+      mode:                                  _VIEW,
       resourcesData:                         {
         [`${ ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS }`]: [],
         [`${ ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES }`]:   [],
@@ -283,6 +287,8 @@ export default {
     <div class="mt-20 mb-20">
       <BuildMedia
         :registration-endpoint-list="registrationEndpoints"
+        :resource="resource"
+        :mode="mode"
       />
     </div>
     <!-- Tables -->

--- a/pkg/elemental/detail/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/detail/elemental.cattle.io.machineregistration.vue
@@ -32,6 +32,10 @@ export default {
       type:     String,
       required: true
     },
+    resource: {
+      type:     String,
+      required: true
+    },
   },
   data() {
     return {
@@ -115,6 +119,8 @@ export default {
       <BuildMedia
         :display-reg-endpoints="false"
         :registration-endpoint="`${value.metadata.namespace}/${value.metadata.name}`"
+        :resource="resource"
+        :mode="mode"
       />
     </div>
     <div

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -16,7 +16,7 @@ import { exceptionToErrorsArray } from '@shell/utils/error';
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 
-import { semverVersionCheck, getOperatorVersion, getGatedFeatures, MACH_REG_CONFIG_DEFAULTS } from '../utils/feature-versioning';
+import { semverVersionCheck, getOperatorVersion, getGatedFeature, MACH_REG_CONFIG_DEFAULTS } from '../utils/feature-versioning';
 import { OLD_DEFAULT_CREATION_YAML, DEFAULT_CREATION_YAML } from '../models/elemental.cattle.io.machineregistration';
 
 export default {
@@ -51,8 +51,8 @@ export default {
     // in CREATE mode, since YAMLEditor doesn't live update, we need to force a re-render of the component for it to update
     if (this.mode === _CREATE) {
       const operatorVersion = await getOperatorVersion(this.$store);
-      const gatedFeatures = getGatedFeatures(this.resource, this.mode, MACH_REG_CONFIG_DEFAULTS);
-      const minOperatorVersion = gatedFeatures?.[0]?.minOperatorVersion || '';
+      const gatedFeature = getGatedFeature(this.resource, this.mode, MACH_REG_CONFIG_DEFAULTS);
+      const minOperatorVersion = gatedFeature?.minOperatorVersion || '';
 
       this.newCloudConfigcompatibilityCheck = semverVersionCheck(operatorVersion, minOperatorVersion);
 
@@ -70,7 +70,8 @@ export default {
       cloudConfig:                      typeof this.value.spec === 'string' ? this.value.spec : saferDump(this.value.spec),
       newCloudConfigcompatibilityCheck: false,
       yamlErrors:                       null,
-      isFormValid:                      true
+      isFormValid:                      true,
+      gatedFeature:                     {}
     };
   },
   watch: {

--- a/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.machineregistration.vue
@@ -16,7 +16,7 @@ import { exceptionToErrorsArray } from '@shell/utils/error';
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 
-import { semverVersionCheck, getOperatorVersion, getGatedFeature, MACH_REG_CONFIG_DEFAULTS } from '../utils/feature-versioning';
+import { getOperatorVersion, checkGatedFeatureCompatibility, MACH_REG_CONFIG_DEFAULTS } from '../utils/feature-versioning';
 import { OLD_DEFAULT_CREATION_YAML, DEFAULT_CREATION_YAML } from '../models/elemental.cattle.io.machineregistration';
 
 export default {
@@ -51,10 +51,8 @@ export default {
     // in CREATE mode, since YAMLEditor doesn't live update, we need to force a re-render of the component for it to update
     if (this.mode === _CREATE) {
       const operatorVersion = await getOperatorVersion(this.$store);
-      const gatedFeature = getGatedFeature(this.resource, this.mode, MACH_REG_CONFIG_DEFAULTS);
-      const minOperatorVersion = gatedFeature?.minOperatorVersion || '';
 
-      this.newCloudConfigcompatibilityCheck = semverVersionCheck(operatorVersion, minOperatorVersion);
+      this.newCloudConfigcompatibilityCheck = checkGatedFeatureCompatibility(this.resource, this.mode, MACH_REG_CONFIG_DEFAULTS, operatorVersion);
 
       if (!this.value.spec) {
         this.value.spec = this.newCloudConfigcompatibilityCheck ? DEFAULT_CREATION_YAML : OLD_DEFAULT_CREATION_YAML;
@@ -70,8 +68,7 @@ export default {
       cloudConfig:                      typeof this.value.spec === 'string' ? this.value.spec : saferDump(this.value.spec),
       newCloudConfigcompatibilityCheck: false,
       yamlErrors:                       null,
-      isFormValid:                      true,
-      gatedFeature:                     {}
+      isFormValid:                      true
     };
   },
   watch: {

--- a/pkg/elemental/models/elemental.cattle.io.machineregistration.js
+++ b/pkg/elemental/models/elemental.cattle.io.machineregistration.js
@@ -8,7 +8,17 @@ import { downloadFile } from '@shell/utils/download';
 import { ELEMENTAL_DEFAULT_NAMESPACE } from '../types';
 import ElementalResource from './elemental-resource';
 
-const DEFAULT_CREATION_YAML = `config:
+export const OLD_DEFAULT_CREATION_YAML = `config:
+  cloud-config:
+    users:
+    - name: root
+      passwd: root
+  elemental:
+    install:
+      poweroff: true
+      device: /dev/nvme0n1`;
+
+export const DEFAULT_CREATION_YAML = `config:
   cloud-config:
     users:
     - name: root
@@ -32,8 +42,8 @@ const DEFAULT_CREATION_YAML = `config:
 
 export default class MachineRegistration extends ElementalResource {
   applyDefaults(vm, mode) {
-    if ( !this.spec ) {
-      Vue.set(this, 'spec', DEFAULT_CREATION_YAML);
+    if ( !this.spec || mode === _CREATE ) {
+      Vue.set(this, 'spec', {});
     }
     if ( !this.metadata || mode === _CREATE ) {
       Vue.set(this, 'metadata', { namespace: ELEMENTAL_DEFAULT_NAMESPACE });

--- a/pkg/elemental/pages/index.vue
+++ b/pkg/elemental/pages/index.vue
@@ -16,17 +16,18 @@ export default {
     // this covers scenario where Elemental Operator is deleted from Apps and we lose the Elemental Admin role for Standard Users...
     if (this.$store.getters['management/canList'](ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS)) {
       let installedApps;
+
       // needed to check if operator is installed
       if (this.$store.getters['management/canList'](CATALOG.APP)) {
         installedApps = await this.$store.dispatch('management/findAll', { type: CATALOG.APP });
       }
 
-      const elementalSchema = this.$store.getters['management/schemaFor'](ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES)
+      const elementalSchema = this.$store.getters['management/schemaFor'](ELEMENTAL_SCHEMA_IDS.MACHINE_INVENTORIES);
 
       // we need to check for the length of the response
       // due to some issue with a standard-user, which can list apps
       // but the list comes up empty []
-      const isElementalOperatorNotInstalledOnApps = installedApps?.length && !installedApps?.find(item => item.id.includes('elemental-operator'));
+      const isElementalOperatorNotInstalledOnApps = installedApps?.length && !installedApps?.find(item => item.id.includes('elemental-operator') && !item.id.includes('elemental-operator-crds'));
 
       // check if operator is installed
       if (!elementalSchema || isElementalOperatorNotInstalledOnApps) {

--- a/pkg/elemental/utils/feature-versioning.ts
+++ b/pkg/elemental/utils/feature-versioning.ts
@@ -1,0 +1,86 @@
+import semver from 'semver';
+
+import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
+import { CATALOG } from '@shell/config/types';
+import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
+import { ELEMENTAL_TYPES } from '../types';
+
+interface FeaturesGatingConfig {
+  area: string,
+  mode: string[],
+  minOperatorVersion: string,
+  features: string[],
+}
+
+export const MACH_REG_CONFIG_DEFAULTS:string = 'machine-reg-config-defaults';
+export const BUILD_MEDIA_RAW_SUPPORT:string = 'build-media-raw-support';
+
+const FEATURES_GATING:FeaturesGatingConfig[] = [
+  {
+    area:               ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
+    mode:               [_CREATE],
+    minOperatorVersion: '103.0.0',
+    features:           [MACH_REG_CONFIG_DEFAULTS]
+  },
+  {
+    area:               ELEMENTAL_TYPES.DASHBOARD,
+    mode:               [_VIEW],
+    minOperatorVersion: '103.0.0',
+    features:           [BUILD_MEDIA_RAW_SUPPORT]
+  },
+  {
+    area:               ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
+    mode:               [_VIEW],
+    minOperatorVersion: '103.0.0',
+    features:           [BUILD_MEDIA_RAW_SUPPORT]
+  }
+];
+
+/**
+ * Get the current elemental-operator version
+ * @param any store
+ * @param any alreadyInstalledApps
+ * @returns Promise<string | void>
+ */
+export async function getOperatorVersion(store: any, alreadyInstalledApps:any = null, isRoot:Boolean = false): Promise<string | void> {
+  if (alreadyInstalledApps) {
+    const operator = alreadyInstalledApps?.find((item: any) => item.id.includes('elemental-operator') && !item.id.includes('elemental-operator-crds'));
+
+    return operator?.versionDisplay;
+  }
+
+  // needed to check if operator is installed
+  if (store.getters['management/canList'](CATALOG.APP)) {
+    const installedApps = await store.dispatch('management/findAll', { type: CATALOG.APP }, { root: isRoot });
+    const operator = installedApps?.find((item: any) => item.id.includes('elemental-operator') && !item.id.includes('elemental-operator-crds'));
+
+    return operator?.versionDisplay;
+  }
+
+  return '';
+}
+
+/**
+ * Get all of the gated features based on resource + mode + string
+ * @param string
+ * @param string
+ * @param string
+ * @returns FeaturesGatingConfig[] | [] | void
+ */
+export function getGatedFeatures(resource: string, mode: string, feature: string): FeaturesGatingConfig[] | [] | void {
+  if (resource && mode) {
+    return FEATURES_GATING.filter(feat => feat.area === resource && feat.mode.includes(mode) && feat.features.includes(feature));
+  }
+
+  return [];
+}
+
+/**
+ * Determines if a given feature is enabled by doing a semver version comparison
+ * @param string
+ * @param string
+ * @returns Boolean | void
+ */
+export function semverVersionCheck(operatorVersion: string, limitVersion: string): Boolean | void {
+  return semver.gte(operatorVersion, limitVersion);
+}

--- a/pkg/elemental/utils/feature-versioning.ts
+++ b/pkg/elemental/utils/feature-versioning.ts
@@ -12,6 +12,7 @@ interface FeaturesGatingConfig {
   features: string[],
 }
 
+// features to be gated to specific operator versions
 export const MACH_REG_CONFIG_DEFAULTS:string = 'machine-reg-config-defaults';
 export const BUILD_MEDIA_RAW_SUPPORT:string = 'build-media-raw-support';
 
@@ -38,8 +39,7 @@ const FEATURES_GATING:FeaturesGatingConfig[] = [
 
 /**
  * Get the current elemental-operator version
- * @param any store
- * @param any alreadyInstalledApps
+ * @param any Vue store
  * @returns Promise<string | void>
  */
 export async function getOperatorVersion(store: any): Promise<string | void> {
@@ -54,26 +54,23 @@ export async function getOperatorVersion(store: any): Promise<string | void> {
 }
 
 /**
- * Get the gated feature based on resource + mode + string
- * @param string
- * @param string
- * @param string
- * @returns FeaturesGatingConfig | {} | void
+ * Check the gated feature compatibility with the current Elemental Operator version installed
+ * @param string resource type (ex: Deployment)
+ * @param string UI mode (ex: edit, create, view)
+ * @param string Elemental feature (ex: Build media, cloud config)
+ * @param string Elemental Operator version
+ * @returns Boolean
  */
-export function getGatedFeature(resource: string, mode: string, feature: string): FeaturesGatingConfig | {} | void {
-  if (resource && mode) {
-    return FEATURES_GATING.find(feat => feat.area === resource && feat.mode.includes(mode) && feat.features.includes(feature));
+export function checkGatedFeatureCompatibility(resource: string, mode: string, feature: string, operatorVersion: string): Boolean {
+  if (resource && mode && feature) {
+    const gatedFeature = FEATURES_GATING.find(feat => feat.area === resource && feat.mode.includes(mode) && feat.features.includes(feature));
+
+    if (!gatedFeature?.minOperatorVersion || !operatorVersion) {
+      return false;
+    }
+
+    return semver.gte(operatorVersion, gatedFeature?.minOperatorVersion);
   }
 
-  return {};
-}
-
-/**
- * Determines if a given feature is enabled by doing a semver version comparison
- * @param string
- * @param string
- * @returns Boolean | void
- */
-export function semverVersionCheck(operatorVersion: string, operatorMinVersion: string): Boolean | void {
-  return semver.gte(operatorVersion, operatorMinVersion);
+  return false;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,10 +2969,10 @@
   dependencies:
     lodash.debounce "4.0.8"
 
-"@rancher/shell@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-0.5.1.tgz#4ee59f4f60b6bba54995f00e289dcd64d97f162a"
-  integrity sha512-oCmXZ9MDw9jh7plGmYT9ZnB2gHqs5FLgB22HEgUl46R7t94Tms3Z5VivN1JMS77R++C3jdC/EVpjgisKslK4Pg==
+"@rancher/shell@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-0.5.2.tgz#ab11c8aa03001ba36734ec94f333d48f56846cdd"
+  integrity sha512-u48zCEhimZKh7WIJDGo7dLbkIV/PbRUE88/hkiQ1+xi5gZRgqO/rFCfiALzJKl35d7cCTXqWNodJnTpvwRn8JA==
   dependencies:
     "@aws-sdk/client-ec2" "3.1.0"
     "@aws-sdk/client-eks" "3.1.0"
@@ -3486,6 +3486,11 @@
   version "0.2.33"
   resolved "https://registry.yarnpkg.com/@types/relateurl/-/relateurl-0.2.33.tgz#fa174c30100d91e88d7b0ba60cefd7e8c532516f"
   integrity sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==
+
+"@types/semver@^7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
 "@types/send@*":
   version "0.17.4"
@@ -14658,6 +14663,13 @@ semver@^7.0.0, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semve
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
@@ -15329,7 +15341,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15346,6 +15358,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15397,7 +15418,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15417,6 +15438,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -17064,7 +17092,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17086,6 +17114,15 @@ wrap-ansi@^6.0.0, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Fixes #170 

Implement feature versioning mechanism that's bound to Elemental backend version, which is captured from the `elemental-operator` `deployment` label `app.kubernetes.io/version`.

This impact areas such as: 
-`BuildMedia` (support for RAW disk image build) which can be found in `Dashboard` view and `machine registration` detail view.
- `machine registration` cloud config, which can be found in `machine registration` create view.

**To test:**
- Install `elemental-operator-crds` manually, via kubectl (so it installs the dev version with the label):
```
helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator-crds oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-crds-chart
```

- Install `elemental-operator` manually, via kubectl:
```
helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
```

- Run this branch and check the areas above mentioned:
```
-`BuildMedia` (support for RAW disk image build) which can be found in `Dashboard` view and `machine registration` detail view.
- `machine registration` cloud config, which can be found in `machine registration` create view.
```

- Edit `pkg/elemental/utils/feature-versioning.ts` lines `18-37`, change version number there displayed and check impact on each of the areas mentioned (no support for RAW disk image build and smaller cloud config for machine registration)

**Screenshots of areas of impact**
![Screenshot 2024-04-04 at 16 57 54](https://github.com/rancher/elemental-ui/assets/97888974/3125fc36-5d1c-4f4a-85bf-e5be4a3d5a90)
![Screenshot 2024-04-04 at 16 57 56](https://github.com/rancher/elemental-ui/assets/97888974/bbc632ce-ad3d-45f8-b457-bf1449733201)
![Screenshot 2024-04-04 at 16 57 49](https://github.com/rancher/elemental-ui/assets/97888974/bc16ec1a-c6b2-43cf-8405-72076379109e)
