### PR TITLE
Fix Wrong default cloud config file with standard user 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental-ui",
   "description": "Elemental UI extension",
-  "version": "1.3.1-rc5",
+  "version": "1.3.1-rc6",
   "private": false,
   "engines": {
     "node": ">=12"

--- a/pkg/elemental/config/elemental-types.js
+++ b/pkg/elemental/config/elemental-types.js
@@ -10,6 +10,7 @@ export const ELEMENTAL_SCHEMA_IDS = {
   MACHINE_INV_SELECTOR:           'elemental.cattle.io.machineinventoryselector',
   MACHINE_INV_SELECTOR_TEMPLATES: 'elemental.cattle.io.machineinventoryselectortemplate',
   SEED_IMAGE:                     'elemental.cattle.io.seedimage',
+  METADATA:                       'elemental.cattle.io.metadata',
 };
 
 export const KIND = { MACHINE_INV_SELECTOR_TEMPLATES: 'MachineInventorySelectorTemplate' };

--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental",
   "description": "OS Management extension",
-  "version": "1.3.1-rc5",
+  "version": "1.3.1-rc6",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/elemental/types.js
+++ b/pkg/elemental/types.js
@@ -19,4 +19,5 @@ export const ELEMENTAL_SCHEMAS = {
   MANAGED_OS_VERSIONS:            'elemental.cattle.io.managedosversions',
   MACHINE_INV_SELECTOR:           'elemental.cattle.io.machineinventoryselectors',
   MACHINE_INV_SELECTOR_TEMPLATES: 'elemental.cattle.io.machineinventoryselectortemplates',
+  METADATA:                       'elemental.cattle.io.metadata',
 };

--- a/pkg/elemental/utils/feature-versioning.ts
+++ b/pkg/elemental/utils/feature-versioning.ts
@@ -1,7 +1,6 @@
 import semver from 'semver';
 
 import { _CREATE, _VIEW } from '@shell/config/query-params';
-import { WORKLOAD_TYPES } from '@shell/config/types';
 import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
 import { ELEMENTAL_TYPES } from '../types';
 
@@ -20,19 +19,19 @@ const FEATURES_GATING:FeaturesGatingConfig[] = [
   {
     area:               ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
     mode:               [_CREATE],
-    minOperatorVersion: '1.6.0',
+    minOperatorVersion: '1.6.2',
     features:           [MACH_REG_CONFIG_DEFAULTS]
   },
   {
     area:               ELEMENTAL_TYPES.DASHBOARD,
     mode:               [_VIEW],
-    minOperatorVersion: '1.6.0',
+    minOperatorVersion: '1.6.2',
     features:           [BUILD_MEDIA_RAW_SUPPORT]
   },
   {
     area:               ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
     mode:               [_VIEW],
-    minOperatorVersion: '1.6.0',
+    minOperatorVersion: '1.6.2',
     features:           [BUILD_MEDIA_RAW_SUPPORT]
   }
 ];
@@ -43,11 +42,11 @@ const FEATURES_GATING:FeaturesGatingConfig[] = [
  * @returns Promise<string | void>
  */
 export async function getOperatorVersion(store: any): Promise<string | void> {
-  // needed to check operator version installed (on the deployment)
-  if (store.getters['management/canList'](WORKLOAD_TYPES.DEPLOYMENT)) {
-    const elementalOperatorDeployment = await store.dispatch('management/find', { type: WORKLOAD_TYPES.DEPLOYMENT, id: 'cattle-elemental-system/elemental-operator' });
+  // needed to check operator version installed (on a custom CRD called metadata, which is installed/created from elemental-operator)
+  if (store.getters['management/canList'](ELEMENTAL_SCHEMA_IDS.METADATA)) {
+    const elementalOperatorMetadata = await store.dispatch('management/find', { type: ELEMENTAL_SCHEMA_IDS.METADATA, id: 'cattle-elemental-system/elemental-operator' });
 
-    return elementalOperatorDeployment?.metadata?.labels?.['app.kubernetes.io/version'] || '0.1.0';
+    return elementalOperatorMetadata?.spec?.appVersion || '0.1.0';
   }
 
   return '0.1.0';


### PR DESCRIPTION
Fixes #175 

- change logic to get `elemental-operator` version from custom CRD included in `elemental-operator` 
- change min operator version for feature gating to `1.6.2` 
- bump version to prepare for RC release

**Screenshots/video**
https://github.com/rancher/elemental-ui/assets/97888974/8348205d-9a4a-4229-b6c6-6bd0f9ec2599

**To test**
- Install elemental UI with current elemental-operator version in PROD and check that with a **standard user** (needs Elemental Administrator role) , in `Registration Endpoint` create, we cannot see the extended cloud config (repro bug)
- Remove the PROD `elemental-operator` and `elemental-operator-crds` app
- Install dev operator, which has the custom CRD with the metadata needed:

```
helm upgrade --install elemental-operator-crds oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-crds-chart --namespace cattle-elemental-system --create-namespace		

helm upgrade --install elemental-operator oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart --namespace cattle-elemental-system --create-namespace
```
- with a **standard user** (needs Elemental Administrator role) , in `Registration Endpoint` create, we should now see the extended cloud config (check video)