### PR TITLE
 Highlight no-longer-in-sync ManagedOSVersions

### DIFF
--- a/pkg/elemental/components/BuildMedia.vue
+++ b/pkg/elemental/components/BuildMedia.vue
@@ -88,7 +88,7 @@ export default {
         this.filteredManagedOsVersions = this.managedOsVersions.filter(v => v.spec?.type === selectedFilterType) || [];
         this.buildMediaOsVersions = this.filteredManagedOsVersions.map((f) => {
           return {
-            label: `${ f.spec?.metadata?.displayName } ${ f.spec?.version }`,
+            label: `${ f.spec?.metadata?.displayName } ${ f.spec?.version } ${ typeof f.inSync === 'boolean' && !f.inSync ? '(deprecated)' : '' }`,
             value: neu === MEDIA_TYPES.ISO.type ? f.spec?.metadata?.uri : f.spec?.metadata?.upgradeImage,
           };
         });

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -147,6 +147,12 @@ export function init($plugin, store) {
       getValue:      row => row.metadata?.ownerReferences?.[0]?.name || '---',
       sort:          ['metadata.ownerReferences.[0].name']
     },
+    {
+      name:          'OsVersionInSync',
+      labelKey:      'tableHeaders.inSync',
+      getValue:      row => row.inSync || '---',
+      sort:          ['inSync']
+    },
     AGE
   ]);
 

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -150,7 +150,7 @@ export function init($plugin, store) {
     {
       name:          'OsVersionInSync',
       labelKey:      'tableHeaders.inSync',
-      value:         'inSyncFormatter',
+      value:         'inSyncFormatterText',
       formatter:     'InSync',
       sort:          ['inSync']
     },

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -150,7 +150,8 @@ export function init($plugin, store) {
     {
       name:          'OsVersionInSync',
       labelKey:      'tableHeaders.inSync',
-      getValue:      row => row.inSync || '---',
+      value:         'inSyncFormatter',
+      formatter:     'InSync',
       sort:          ['inSync']
     },
     AGE

--- a/pkg/elemental/formatters/InSync.vue
+++ b/pkg/elemental/formatters/InSync.vue
@@ -1,0 +1,27 @@
+<script>
+export default {
+  props:      {
+    value: {
+      type:     String,
+      default: () => ''
+    }
+  },
+  computed: {
+    isOutOfSync() {
+      return this.value === this.t('elemental.osVersions.outOfSync');
+    }
+  },
+};
+</script>
+
+<template>
+  <p :class="{ 'outOfSync': isOutOfSync }">
+    {{ value }}
+  </p>
+</template>
+
+<style lang="scss" scoped>
+.outOfSync {
+  color: var(--error);
+}
+</style>

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -193,6 +193,10 @@ elemental:
     createCluster: Create Elemental Cluster
     import: YAML import
     updateForCreateClusterError: Error updating Inventory of Machines with label for creating a cluster
+  osVersions:
+    notApplicable: n/a
+    inSync: In sync
+    outOfSync: Out of sync
   osversionchannels:
     create:
       configuration: Configuration

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -23,6 +23,7 @@ tableHeaders:
   osVersionChannel: OS Version Channel
   channelImage: Channel Image
   targetClusters: Target Clusters
+  inSync: In Sync
 
 typeLabel:
   elemental:  |-

--- a/pkg/elemental/models/elemental.cattle.io.managedosversion.js
+++ b/pkg/elemental/models/elemental.cattle.io.managedosversion.js
@@ -1,0 +1,7 @@
+import ElementalResource from './elemental-resource';
+
+export default class ManagedOsVersion extends ElementalResource {
+  get inSync() {
+    return this.spec?.type === 'iso' && Object.keys(this.metadata?.annotations || {}).includes('elemental.cattle.io/channel-no-longer-in-sync') ? !this.metadata?.annotations['elemental.cattle.io/channel-no-longer-in-sync'] : '---';
+  }
+}

--- a/pkg/elemental/models/elemental.cattle.io.managedosversion.js
+++ b/pkg/elemental/models/elemental.cattle.io.managedosversion.js
@@ -1,10 +1,8 @@
 import ElementalResource from './elemental-resource';
 
 export default class ManagedOsVersion extends ElementalResource {
-  get inSyncFormatter() {
-    if (!(this.spec?.type === 'iso')) {
-      return this.t('elemental.osVersions.notApplicable');
-    } else if (Object.keys(this.metadata?.annotations || {}).includes('elemental.cattle.io/channel-no-longer-in-sync')) {
+  get inSyncFormatterText() {
+    if (Object.keys(this.metadata?.annotations || {}).includes('elemental.cattle.io/channel-no-longer-in-sync')) {
       return this.metadata?.annotations['elemental.cattle.io/channel-no-longer-in-sync'] === 'true' ? this.t('elemental.osVersions.outOfSync') : this.t('elemental.osVersions.inSync');
     } else {
       return this.t('elemental.osVersions.inSync');
@@ -12,9 +10,7 @@ export default class ManagedOsVersion extends ElementalResource {
   }
 
   get inSync() {
-    if (!(this.spec?.type === 'iso')) {
-      return true;
-    } else if (Object.keys(this.metadata?.annotations || {}).includes('elemental.cattle.io/channel-no-longer-in-sync')) {
+    if (Object.keys(this.metadata?.annotations || {}).includes('elemental.cattle.io/channel-no-longer-in-sync')) {
       return this.metadata?.annotations['elemental.cattle.io/channel-no-longer-in-sync'] !== 'true';
     } else {
       return true;

--- a/pkg/elemental/models/elemental.cattle.io.managedosversion.js
+++ b/pkg/elemental/models/elemental.cattle.io.managedosversion.js
@@ -1,7 +1,23 @@
 import ElementalResource from './elemental-resource';
 
 export default class ManagedOsVersion extends ElementalResource {
+  get inSyncFormatter() {
+    if (!(this.spec?.type === 'iso')) {
+      return this.t('elemental.osVersions.notApplicable');
+    } else if (Object.keys(this.metadata?.annotations || {}).includes('elemental.cattle.io/channel-no-longer-in-sync')) {
+      return this.metadata?.annotations['elemental.cattle.io/channel-no-longer-in-sync'] === 'true' ? this.t('elemental.osVersions.outOfSync') : this.t('elemental.osVersions.inSync');
+    } else {
+      return this.t('elemental.osVersions.inSync');
+    }
+  }
+
   get inSync() {
-    return this.spec?.type === 'iso' && Object.keys(this.metadata?.annotations || {}).includes('elemental.cattle.io/channel-no-longer-in-sync') ? !this.metadata?.annotations['elemental.cattle.io/channel-no-longer-in-sync'] : '---';
+    if (!(this.spec?.type === 'iso')) {
+      return true;
+    } else if (Object.keys(this.metadata?.annotations || {}).includes('elemental.cattle.io/channel-no-longer-in-sync')) {
+      return this.metadata?.annotations['elemental.cattle.io/channel-no-longer-in-sync'] !== 'true';
+    } else {
+      return true;
+    }
   }
 }


### PR DESCRIPTION
Fixes #183 

- add table col to `managedosversions` to display `In sync` status
- add `deprecated` label to out of sync iso managedosversions in Build Media

**To test**
- Needs operator version 1.6 installed
```
helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator-crds \
   oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-crds-chart

helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator \
   oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
```
- go to `Elemental` -> `Advanced` -> `Os Versions` and edit via YAML of the **`ISO's`** to include the following annotation: `elemental.cattle.io/channel-no-longer-in-sync: "true"`
- Check that the table col in `managedosversions` displays the correct `In sync` or `out of sync` status correctly
-  check that the `deprecated` label appears in `out of sync` iso in Build Media

- 
**Video**

https://github.com/user-attachments/assets/40394bd2-bcad-4d32-8f20-f6ed08694ec4




