### PR TITLE
remove deprecated nuxt-link from codebase by replacing with router-link

### DIFF
--- a/pkg/elemental/components/DashboardView.vue
+++ b/pkg/elemental/components/DashboardView.vue
@@ -301,25 +301,25 @@ export default {
           <h3 class="mb-20">
             {{ machineRegTitle }}
           </h3>
-          <nuxt-link
+          <router-link
             :to="machineRegListLocation"
             class="table-title-block-link"
             data-testid="manage-reg-btn"
           >
             {{ t('elemental.dashboard.manageReg') }}
-          </nuxt-link>
+          </router-link>
         </div>
         <div
           v-if="machineRegRows?.length === 0"
           class="empty-table-state"
         >
           <p>{{ t('elemental.dashboard.noMachineReg') }}</p>
-          <nuxt-link
+          <router-link
             :to="machineRegCreateLocation"
             data-testid="create-machine-reg-btn"
           >
             {{ t('elemental.dashboard.noMachineRegAction') }}
-          </nuxt-link>
+          </router-link>
         </div>
         <ResourceTable
           v-else
@@ -345,25 +345,25 @@ export default {
           <h3 class="mb-20">
             {{ managedOsTitle }}
           </h3>
-          <nuxt-link
+          <router-link
             :to="managedOsListLocation"
             class="table-title-block-link"
             data-testid="manage-update-group-btn"
           >
             {{ t('elemental.dashboard.manageOsImageUpgrade') }}
-          </nuxt-link>
+          </router-link>
         </div>
         <div
           v-if="managedOsRows?.length === 0"
           class="empty-table-state"
         >
           <p>{{ t('elemental.dashboard.noManageOs') }}</p>
-          <nuxt-link
+          <router-link
             :to="managedOsCreateLocation"
             data-testid="create-update-group-btn"
           >
             {{ t('elemental.dashboard.noManageOsAction') }}
-          </nuxt-link>
+          </router-link>
         </div>
         <ResourceTable
           v-else
@@ -414,19 +414,16 @@ export default {
 
       h1 {
         margin: 0 15px 0 0;
-        font-weight: bold;
       }
 
       p {
         font-size: 18px;
-        font-weight: bold;
       }
     }
 
     button {
       justify-content: center;
       width: fit-content;
-      font-weight: bold;
       margin-top: 12px;
     }
   }


### PR DESCRIPTION
Fixes #197 

- remove deprecated nuxt-link from codebase by replacing with router-link. Needed a slight style adjustment.

<img width="1017" alt="Screenshot 2024-07-12 at 14 37 36" src="https://github.com/user-attachments/assets/6469ba17-5273-44ba-bddf-ef9ab418c1ee">
