### PR TITLE
backport: warn users build media downl btn seed img

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "publish-pkgs": "./node_modules/@rancher/shell/scripts/extension/publish"
   },
   "resolutions": {
-    "**/webpack": "4"
+    "**/webpack": "4",
+    "glob": "7.2.3"
   }
 }

--- a/pkg/elemental/components/BuildMedia.vue
+++ b/pkg/elemental/components/BuildMedia.vue
@@ -7,7 +7,7 @@ import { randomStr, CHARSET } from '@shell/utils/string';
 import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
 import { getOperatorVersion, checkGatedFeatureCompatibility, BUILD_MEDIA_RAW_SUPPORT } from '../utils/feature-versioning';
 
-const MEDIA_TYPES = {
+export const MEDIA_TYPES = {
   RAW: {
     filterType: 'container',
     type:       'raw',
@@ -283,6 +283,12 @@ export default {
         </a>
       </div>
     </div>
+    <div class="row mb-10">
+      <div class="col span-9">
+        <p v-clean-html="t('elemental.machineRegistration.edit.userWarning',{}, true)" class="user-warn">
+        </p>
+      </div>
+    </div>
     <Banner
       v-if="mediaBuildTriggerError || mediaBuildProcessError"
       color="error"
@@ -294,5 +300,8 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-
+.user-warn {
+  font-size: 13px;
+  color: var(--darker);
+}
 </style>

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -177,6 +177,19 @@ export function init($plugin, store) {
     customRoute: createElementalRoute('resource', { resource: ELEMENTAL_SCHEMA_IDS.SEED_IMAGE })
   });
 
+  headers(ELEMENTAL_SCHEMA_IDS.SEED_IMAGE, [
+    STATE,
+    NAME_COL,
+    NAMESPACE_COL,
+    {
+      name:      'downloadSeedImage',
+      labelKey:  'tableHeaders.download',
+      value:     'status',
+      formatter: 'SeedImageDownload'
+    },
+    AGE
+  ]);
+
   basicType([
     ELEMENTAL_TYPES.DASHBOARD,
     ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,

--- a/pkg/elemental/formatters/SeedImageDownload.vue
+++ b/pkg/elemental/formatters/SeedImageDownload.vue
@@ -1,0 +1,51 @@
+<script>
+import { MEDIA_TYPES } from '../components/BuildMedia.vue';
+
+export default {
+  props:      {
+    value: {
+      type:     Object,
+      default: () => {}
+    }
+  },
+  computed: {
+    hasDownloadLink() {
+      return !!this.value?.downloadURL;
+    },
+  },
+  methods: {
+    downloadSeedImage(ev) {
+      ev.preventDefault();
+
+      if (this.hasDownloadLink) {
+        const downloadUrl = this.value?.downloadURL;
+        const link = document.createElement('a');
+
+        const isIso = !!(this.value?.downloadURL && this.value?.downloadURL.includes('.iso'));
+
+        link.download = `elemental.${ isIso ? MEDIA_TYPES.ISO.extension : MEDIA_TYPES.RAW.extension }`;
+        link.href = downloadUrl;
+        document.body.appendChild(link);
+
+        link.click();
+        document.body.removeChild(link);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <button
+      v-if="hasDownloadLink"
+      class="btn role-primary"
+      @click="downloadSeedImage"
+    >
+      {{ t('tableHeaders.download') }}
+    </button>
+    <p v-else>
+      -
+    </p>
+  </div>
+</template>

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -152,7 +152,7 @@ elemental:
       machineInventoryLabelKeyNameLength: One of the labels for Inventory of Machines has a key name that exceeds the 63 characters limit. Please shorten the length of the label key name.
       machineInventoryLabelValueLength: One of the labels for Inventory of Machines has a value that exceeds the 63 characters limit. Please shorten the length of the label value.
     edit:
-      userWarning: '<b>Note:</b> Wait for the Build Media to be completed to download the desired Media item. If you navigate away from this page, you will not be able to download the Media file being built'
+      userWarning: '<b>Note:</b> Wait for the Build Media to be completed before downloading the desired Media item. If you navigate away from this page, you will not be able to download the Media file being built.'
       imageSetup: Setting up an OS image
       downloadMachineRegistrationFile: 'Download the Registration Endpoint Configuration file in order to manually prepare your ISO image. Instructions <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://elemental.docs.rancher.com/custom-install">here</a>.'
       buildMediaTitle: Create OS image

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -152,6 +152,7 @@ elemental:
       machineInventoryLabelKeyNameLength: One of the labels for Inventory of Machines has a key name that exceeds the 63 characters limit. Please shorten the length of the label key name.
       machineInventoryLabelValueLength: One of the labels for Inventory of Machines has a value that exceeds the 63 characters limit. Please shorten the length of the label value.
     edit:
+      userWarning: '<b>Note:</b> Wait for the Build Media to be completed to download the desired Media item. If you navigate away from this page, you will not be able to download the Media file being built'
       imageSetup: Setting up an OS image
       downloadMachineRegistrationFile: 'Download the Registration Endpoint Configuration file in order to manually prepare your ISO image. Instructions <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://elemental.docs.rancher.com/custom-install">here</a>.'
       buildMediaTitle: Create OS image


### PR DESCRIPTION
Backport - Fixes #204 

- add download btn to seedImage list view
- add note to warn users about navigating out of page when building media images

**Screenshots**

<img width="2144" alt="Screenshot 2024-07-19 at 16 55 50" src="https://github.com/user-attachments/assets/53d7c198-9984-4ac0-a375-3646795975e2">
<img width="2144" alt="Screenshot 2024-07-19 at 16 55 46" src="https://github.com/user-attachments/assets/bb1527cf-eddb-4349-aa6a-0dfc0a33ecbb">
<img width="2144" alt="Screenshot 2024-07-19 at 16 55 42" src="https://github.com/user-attachments/assets/b8b5f185-9055-4e0c-a2c6-0edf2f2f6b2e">