### PR TITLE
backport for issue 206

### DIFF
--- a/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
@@ -171,7 +171,7 @@ export default {
         <h3>{{ t('elemental.osimage.create.spec') }}</h3>
         <LabeledSelect
           v-model="clusterTargets"
-          class="mb-20"
+          class="mb-10"
           data-testid="cluster-target"
           :label="t('elemental.osimage.create.targetCluster.label')"
           :placeholder="t('elemental.osimage.create.targetCluster.placeholder', null, true)"
@@ -180,6 +180,7 @@ export default {
           :multiple="true"
           @input="handleClusterTargetChange($event)"
         />
+        <p v-clean-html="t('elemental.osimage.create.userWarning',{}, true)" class="user-warn mb-20"></p>
         <RadioGroup
           v-model="useManagedOsImages"
           class="mb-20"
@@ -215,3 +216,10 @@ export default {
     </div>
   </CruResource>
 </template>
+
+<style lang="scss" scoped>
+.user-warn {
+  font-size: 13px;
+  color: var(--darker);
+}
+</style>

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -127,6 +127,7 @@ elemental:
         elementalClusters: Manage Elemental Clusters
   osimage:
     create:
+      userWarning: "<b>Note:</b> Elemental clusters that have been targeted by another OS Group won't show up in the Target Cluster list unless that OS Group is deleted"
       configuration: Configuration
       spec: Spec
       name:


### PR DESCRIPTION
Backport - Fixes #206 

- Adds copy to update group target clusters to warn users about clusters that are already targeted won't show up

<img width="2144" alt="Screenshot 2024-07-19 at 17 16 29" src="https://github.com/user-attachments/assets/c4113d64-3b2e-4837-82a3-bf6812fe25f8">

