### PR TITLE
Update rancher version annotation to bind it to rancher 2.8.x and not greater versions

### DIFF
--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -6,7 +6,7 @@
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.8.0-0",
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0 < 2.9.0-0",
       "catalog.cattle.io/ui-version": ">= 2.7.2"
     }
   },


### PR DESCRIPTION
Update rancher version annotation to bind it to rancher 2.8.x and not greater versions