### PR TITLE
BP: Support managed os channel automatic deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental-ui",
   "description": "Elemental UI extension",
-  "version": "1.3.1-rc8",
+  "version": "1.3.1-rc9",
   "private": false,
   "engines": {
     "node": ">=12"

--- a/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
@@ -4,11 +4,16 @@ import CruResource from '@shell/components/CruResource.vue';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
+import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 
 export default {
   name:       'ManagedOsVersionChannelEditView',
   components: {
-    Loading, LabeledInput, CruResource, NameNsDescription
+    Loading,
+    LabeledInput,
+    CruResource,
+    NameNsDescription,
+    Checkbox
   },
   mixins:     [CreateEditView],
   props:      {
@@ -44,7 +49,7 @@ export default {
       </div>
     </div>
     <div v-if="value.spec" class="row mb-20">
-      <div class="col span-6 mb-20">
+      <div class="col span-8 mb-20">
         <h3>{{ t('elemental.osversionchannels.create.spec') }}</h3>
         <LabeledInput
           v-model.trim="value.spec.options.image"
@@ -52,6 +57,13 @@ export default {
           :label="t('elemental.osversionchannels.create.registryUri.label')"
           :placeholder="t('elemental.osversionchannels.create.registryUri.placeholder', null, true)"
           :mode="mode"
+        />
+        <Checkbox
+          v-model="value.spec.deleteNoLongerInSyncVersions"
+          :mode="mode"
+          :label="t('elemental.osversionchannels.create.automaticDelete')"
+          data-testid="os-version-channel-automatic-deletion"
+          class="mt-20"
         />
       </div>
     </div>

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -196,6 +196,7 @@ elemental:
     create:
       configuration: Configuration
       spec: Spec
+      automaticDelete: Automatically delete deprecated OS versions that are no longer included in the channel
       registryUri:
         label: Image registry path
         placeholder: Enter an image registry path

--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental",
   "description": "OS Management extension",
-  "version": "1.3.1-rc8",
+  "version": "1.3.1-rc9",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
Backport of PR https://github.com/rancher/elemental-ui/pull/195 + version bump

Fixes #189 

- Add checkbox to support managed os channel automatic deletion (boolean as per https://elemental.docs.rancher.com/next/managedosversionchannel-reference/#managedosversionchannelspec-reference) -> `spec.deleteNoLongerInSyncVersions` boolean flag

**To test**
- Needs operator version 1.6 installed
```
helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator-crds \
   oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-crds-chart

helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator \
   oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
```
- go to `Elemental` -> `Advanced` -> `Os Version Channels` and create a new channel with the checkbox selected and see network or YAML to confirm that option is set to `true` (default is `false`)


**Video**
https://github.com/user-attachments/assets/c60da4fa-2469-460b-bc5f-39eab5e4de16

