### PR TITLE
gate features to a specific elemental operator version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental-ui",
   "description": "Elemental UI extension",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0-rc2",
   "private": false,
   "engines": {
     "node": ">=12"

--- a/pkg/elemental/components/BuildMedia.vue
+++ b/pkg/elemental/components/BuildMedia.vue
@@ -5,7 +5,14 @@ import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
 import { randomStr, CHARSET } from '@shell/utils/string';
 import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
-import { getOperatorVersion, checkGatedFeatureCompatibility, BUILD_MEDIA_RAW_SUPPORT } from '../utils/feature-versioning';
+import {
+  getOperatorVersion,
+  checkGatedFeatureCompatibility,
+  BUILD_MEDIA_RAW_SUPPORT,
+  CHANNEL_NO_LONGER_IN_SYNC,
+  ALL_AREAS,
+  ALL_MODES,
+} from '../utils/feature-versioning';
 
 export const MEDIA_TYPES = {
   RAW: {
@@ -88,7 +95,7 @@ export default {
         this.filteredManagedOsVersions = this.managedOsVersions.filter(v => v.spec?.type === selectedFilterType) || [];
         this.buildMediaOsVersions = this.filteredManagedOsVersions.map((f) => {
           return {
-            label: `${ f.spec?.metadata?.displayName } ${ f.spec?.version } ${ typeof f.inSync === 'boolean' && !f.inSync ? '(deprecated)' : '' }`,
+            label: `${ f.spec?.metadata?.displayName } ${ f.spec?.version } ${ this.supportChannelNoLongerInSync && typeof f.inSync === 'boolean' && !f.inSync ? '(deprecated)' : '' }`,
             value: neu === MEDIA_TYPES.ISO.type ? f.spec?.metadata?.uri : f.spec?.metadata?.upgradeImage,
           };
         });
@@ -96,6 +103,9 @@ export default {
     }
   },
   computed: {
+    supportChannelNoLongerInSync() {
+      return checkGatedFeatureCompatibility(ALL_AREAS, ALL_MODES, CHANNEL_NO_LONGER_IN_SYNC, this.operatorVersion);
+    },
     isRawDiskImageBuildSupported() {
       const check = checkGatedFeatureCompatibility(this.resource, this.mode, BUILD_MEDIA_RAW_SUPPORT, this.operatorVersion);
 

--- a/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosversionchannel.vue
@@ -5,6 +5,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
+import { getOperatorVersion, checkGatedFeatureCompatibility, DELETE_NO_LONGER_IN_SYNC_CHANNELS } from '../utils/feature-versioning';
 
 export default {
   name:       'ManagedOsVersionChannelEditView',
@@ -24,8 +25,23 @@ export default {
     mode: {
       type:     String,
       required: true
+    },
+    resource: {
+      type:     String,
+      required: true
     }
-  }
+  },
+  async fetch() {
+    this.operatorVersion = await getOperatorVersion(this.$store);
+  },
+  data() {
+    return { operatorVersion: '' };
+  },
+  computed: {
+    supportsNoLongerInSyncChannelDeletion() {
+      return checkGatedFeatureCompatibility(this.resource, this.mode, DELETE_NO_LONGER_IN_SYNC_CHANNELS, this.operatorVersion);
+    }
+  },
 };
 </script>
 
@@ -59,6 +75,7 @@ export default {
           :mode="mode"
         />
         <Checkbox
+          v-if="supportsNoLongerInSyncChannelDeletion"
           v-model="value.spec.deleteNoLongerInSyncVersions"
           :mode="mode"
           :label="t('elemental.osversionchannels.create.automaticDelete')"

--- a/pkg/elemental/formatters/InSync.vue
+++ b/pkg/elemental/formatters/InSync.vue
@@ -1,4 +1,12 @@
 <script>
+import {
+  getOperatorVersion,
+  checkGatedFeatureCompatibility,
+  CHANNEL_NO_LONGER_IN_SYNC,
+  ALL_AREAS,
+  ALL_MODES,
+} from '../utils/feature-versioning';
+
 export default {
   props:      {
     value: {
@@ -6,9 +14,25 @@ export default {
       default: () => ''
     }
   },
+  async fetch() {
+    this.operatorVersion = await getOperatorVersion(this.$store);
+  },
+  data() {
+    return { operatorVersion: '' };
+  },
   computed: {
+    supportChannelNoLongerInSync() {
+      return checkGatedFeatureCompatibility(ALL_AREAS, ALL_MODES, CHANNEL_NO_LONGER_IN_SYNC, this.operatorVersion);
+    },
+    parsedValue() {
+      if (this.supportChannelNoLongerInSync) {
+        return this.value;
+      } else {
+        return this.t('elemental.osVersions.notApplicable');
+      }
+    },
     isOutOfSync() {
-      return this.value === this.t('elemental.osVersions.outOfSync');
+      return this.parsedValue === this.t('elemental.osVersions.outOfSync');
     }
   },
 };
@@ -16,7 +40,7 @@ export default {
 
 <template>
   <p :class="{ 'outOfSync': isOutOfSync }">
-    {{ value }}
+    {{ parsedValue }}
   </p>
 </template>
 

--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental",
   "description": "OS Management extension",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0-rc2",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/elemental/utils/feature-versioning.ts
+++ b/pkg/elemental/utils/feature-versioning.ts
@@ -48,7 +48,7 @@ const FEATURES_GATING:FeaturesGatingConfig[] = [
   {
     area:               ALL_AREAS,
     mode:               [ALL_MODES],
-    minOperatorVersion: '1.6.4',
+    minOperatorVersion: '1.6.3',
     features:           [CHANNEL_NO_LONGER_IN_SYNC]
   }
 ];

--- a/pkg/elemental/utils/feature-versioning.ts
+++ b/pkg/elemental/utils/feature-versioning.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-import { _CREATE, _VIEW } from '@shell/config/query-params';
+import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
 import { ELEMENTAL_TYPES } from '../types';
 
@@ -11,9 +11,14 @@ interface FeaturesGatingConfig {
   features: string[],
 }
 
+export const ALL_AREAS:string = 'all-areas';
+export const ALL_MODES:string = 'all-modes';
+
 // features to be gated to specific operator versions
 export const MACH_REG_CONFIG_DEFAULTS:string = 'machine-reg-config-defaults';
 export const BUILD_MEDIA_RAW_SUPPORT:string = 'build-media-raw-support';
+export const DELETE_NO_LONGER_IN_SYNC_CHANNELS:string = 'delete-no-longer-in-sync-channels';
+export const CHANNEL_NO_LONGER_IN_SYNC:string = 'channel-no-longer-in-sync';
 
 const FEATURES_GATING:FeaturesGatingConfig[] = [
   {
@@ -33,6 +38,18 @@ const FEATURES_GATING:FeaturesGatingConfig[] = [
     mode:               [_VIEW],
     minOperatorVersion: '1.6.2',
     features:           [BUILD_MEDIA_RAW_SUPPORT]
+  },
+  {
+    area:               ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSION_CHANNELS,
+    mode:               [_CREATE, _EDIT],
+    minOperatorVersion: '1.6.3',
+    features:           [DELETE_NO_LONGER_IN_SYNC_CHANNELS]
+  },
+  {
+    area:               ALL_AREAS,
+    mode:               [ALL_MODES],
+    minOperatorVersion: '1.6.4',
+    features:           [CHANNEL_NO_LONGER_IN_SYNC]
   }
 ];
 


### PR DESCRIPTION
- Gate features https://github.com/rancher/elemental-ui/issues/189 and https://github.com/rancher/elemental-ui/pull/187 to elemental-operator `1.6.3`
- Bump version

In the case of the table column `In Sync`, since we cannot control the actual appearance of the table col, I chose to render `n/a` in the case where we don't have the necessary information.
<img width="2309" alt="Screenshot 2024-08-07 at 12 53 38" src="https://github.com/user-attachments/assets/5f5e0dfd-63ec-487c-825a-e3884e7b85bf">

