### PR TITLE
update elemental to use shell 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "elemental-ui",
   "description": "Elemental UI extension",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "private": false,
   "engines": {
     "node": ">=20"
   },
   "dependencies": {
-    "@rancher/shell": "^3.0.0-rc.9"
+    "@rancher/shell": "^3.0.0"
   },
   "resolutions": {
     "@types/node": "~20.10.0",

--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental",
   "description": "OS Management extension",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "private": false,
   "rancher": {
     "annotations": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2824,6 +2824,16 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsep-plugin/assignment@^1.2.1":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz#fcfc5417a04933f7ceee786e8ab498aa3ce2b242"
+  integrity sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==
+
+"@jsep-plugin/regex@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
+  integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
@@ -2910,10 +2920,10 @@
   resolved "https://registry.npmjs.org/@rancher/icons/-/icons-2.0.29.tgz#6546d69768c706bebd66bfa73b36aef3d105987a"
   integrity sha512-qBBqfazS9y5VjV7fJDPNXmxd9AP/2uiE05mKFWP41kpbO+tEb62RnUBXCm14XLeScDZQcOuiAKVHMmvCFzF0BA==
 
-"@rancher/shell@^3.0.0-rc.9":
-  version "3.0.0-rc.9"
-  resolved "https://registry.npmjs.org/@rancher/shell/-/shell-3.0.0-rc.9.tgz#25a76cc6e92c00f06123a9fdfadc8f47846e8f05"
-  integrity sha512-CvrIrAgEJJMCX+hVZaH2PC/hSYo6+mcm2+Vawk5UMwhIuo92VNjrPKWXNUQ7ys1iYWKoS0kj8+SoX4dtSeVDyw==
+"@rancher/shell@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@rancher/shell/-/shell-3.0.0.tgz#2b82ba7695ab8a125c6a911648102ea8ab199101"
+  integrity sha512-FuFxLZQS0UFtGe3z42ISPNGd1+9nPmWnpWhhtGjkvJmsvMWSeNptGY/jGOSuyT5/NUdfzyp0wmnkp1WepsLGjw==
   dependencies:
     "@aws-sdk/client-ec2" "3.658.1"
     "@aws-sdk/client-eks" "3.1.0"
@@ -2962,7 +2972,7 @@
     dagre-d3 "0.6.4"
     dayjs "1.8.29"
     diff2html "3.4.24"
-    dompurify "2.4.5"
+    dompurify "2.5.4"
     element-matches "^0.1.2"
     eslint "7.32.0"
     eslint-config-standard "16.0.3"
@@ -2990,7 +3000,7 @@
     js-yaml "4.1.0"
     js-yaml-loader "1.2.2"
     jsdiff "1.1.1"
-    jsonpath-plus "6.0.1"
+    jsonpath-plus "10.0.0"
     jsrsasign "10.5.25"
     jszip "3.8.0"
     lodash "4.17.21"
@@ -7251,10 +7261,10 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@2.4.5:
-  version "2.4.5"
-  resolved "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz#0e89a27601f0bad978f9a924e7a05d5d2cccdd87"
-  integrity sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==
+dompurify@2.5.4:
+  version "2.5.4"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-2.5.4.tgz#347e91070963b22db31c7c8d0ce9a0a2c3c08746"
+  integrity sha512-l5NNozANzaLPPe0XaAwvg3uZcHtDBnziX/HjsY1UcDj1MxTK8Dd0Kv096jyPK5HRzs/XM5IMj20dW8Fk+HnbUA==
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
@@ -10033,6 +10043,11 @@ jsdom@^16.6.0:
     ws "^7.4.6"
     xml-name-validator "^3.0.0"
 
+jsep@^1.3.9:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz#19feccbfa51d8a79f72480b4b8e40ce2e17152f0"
+  integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
+
 jsesc@^3.0.2, jsesc@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
@@ -10108,10 +10123,14 @@ jsonlint-mod@^1.7.6:
     chalk "^2.4.2"
     underscore "^1.9.1"
 
-jsonpath-plus@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz#9a3e16cedadfab07a3d8dc4e8cd5df4ed8f49c4d"
-  integrity sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==
+jsonpath-plus@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz#7a747d47e20a27867dbbc80b57fd554788b91474"
+  integrity sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==
+  dependencies:
+    "@jsep-plugin/assignment" "^1.2.1"
+    "@jsep-plugin/regex" "^1.0.3"
+    jsep "^1.3.9"
 
 jsprim@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
update elemental to use shell 3.0.0

Build succeeded:
<img width="2400" alt="Screenshot 2024-11-07 at 15 11 11" src="https://github.com/user-attachments/assets/2d16ad86-07e2-4220-af90-962d6d626604">
