### PR TITLE
update annotations so that Elemental 2.0.0 won't run in Rancher 2.10

### DIFF
--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elemental",
   "description": "OS Management extension",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.3",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -5,9 +5,8 @@
   "private": false,
   "rancher": {
     "annotations": {
-      "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.9.0-0",
-      "catalog.cattle.io/ui-extensions-version": ">= 2.0.0-0",
+      "catalog.cattle.io/kube-version": ">= 1.16.0",
+      "catalog.cattle.io/rancher-version": ">= 2.9.0 < 2.10.0",
       "catalog.cattle.io/ui-version": ">= 2.7.2"
     }
   },


### PR DESCRIPTION
- update annotations so that Elemental 2.0.0 won't run in Rancher 2.10