### PR TITLE
Add copy to Inventory of Machines Selector Template to warn users about machine count

### DIFF
--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -180,6 +180,7 @@ elemental:
       machineReg: Registration Endpoint
       machineInv: Inventory of Machines
   clusterGroup:
+    helper: The Machine Count total, even if divided by multiple Machines Pools, must match the total amount of Inventory of Machines, otherwise some Inventory of Machines might not report back if this condition isn't met
     selector:
       label: Inventory of Machines Selector Template
       matchesAll: Matches all {total, number} existing Inventory of Machines

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -180,7 +180,7 @@ elemental:
       machineReg: Registration Endpoint
       machineInv: Inventory of Machines
   clusterGroup:
-    helper: The Machine Count total, even if divided by multiple Machines Pools, must match the total amount of Inventory of Machines, otherwise some Inventory of Machines might not report back if this condition isn't met
+    helper: The Machine Count total, even if divided by multiple Machines Pools, must match the total amount of Inventory of Machines; otherwise, some Inventory of Machines might not report back if this condition isn't met.
     selector:
       label: Inventory of Machines Selector Template
       matchesAll: Matches all {total, number} existing Inventory of Machines

--- a/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
+++ b/pkg/elemental/machine-config/machineinventoryselectortemplate.vue
@@ -113,7 +113,8 @@ export default {
 
 <template>
   <div>
-    <h2 v-t="'elemental.clusterGroup.selector.label'" class="mt-20 mb-20" />
+    <h2 v-t="'elemental.clusterGroup.selector.label'" class="mt-20 mb-5" />
+    <p class="user-warn mb-20">{{ t('elemental.clusterGroup.helper', {}, true) }}</p>
     <MatchExpressions
       :mode="mode"
       :type="elementalType"
@@ -121,6 +122,7 @@ export default {
       :show-remove="false"
       :keys-select-options="machineInventorySelectorKeyOptions"
       @update:value="matchChanged($event)"
+      class="mb-40"
     />
     <Banner v-if="matchingMachineInventories" :color="(matchingMachineInventories.isNone || matchingMachineInventories.isAll ? 'warning' : 'success')">
       <span v-if="matchingMachineInventories.isAll" v-clean-html="t('elemental.clusterGroup.selector.matchesAll', matchingMachineInventories)" />
@@ -132,3 +134,10 @@ export default {
     </Banner>
   </div>
 </template>
+
+<style lang="scss" scoped>
+.user-warn {
+  font-size: 13px;
+  color: var(--darker);
+}
+</style>


### PR DESCRIPTION
Fixes #224 

- add copy to machine config selector template area to explain to users about machine counts and total number of machine inventories

<img width="2029" alt="Screenshot 2024-12-06 at 12 16 58" src="https://github.com/user-attachments/assets/65d134b5-059a-48d1-8140-3a028f0a16f4">
