### PR TITLE
Download SeedImage's checksum

### DIFF
--- a/pkg/elemental/components/BuildMedia.vue
+++ b/pkg/elemental/components/BuildMedia.vue
@@ -146,6 +146,9 @@ export default {
     downloadUrl() {
       return this.seedImageFound?.status?.downloadURL;
     },
+    checksumUrl() {
+      return this.seedImageFound?.status?.checksumURL;
+    },
     isMediaBuilt() {
       if (this.seedImageFound && this.seedImageFound.status?.downloadURL) {
         this.buildBtnCallback(true);
@@ -154,9 +157,6 @@ export default {
       }
 
       return false;
-    },
-    checksumUrl() {
-      return this.seedImageFound?.status?.checksumURL;
     },
     mediaBuildProcessError() {
       if (this.seedImageFound && this.seedImageFound.status?.conditions) {
@@ -275,23 +275,18 @@ export default {
           :disabled="(!isBuildMediaBtnEnabled || isMediaBuilt) ? 'disabled' : null"
           @click="buildMedia"
         />
-        <a
-          :disabled="!isMediaBuilt ? 'disabled' : null"
-          class="btn role-primary"
-          data-testid="download-media-btn"
-          :href="downloadUrl"
-        >
-          {{ t('elemental.machineRegistration.edit.downloadMedia') }}
-        </a>
+        
         <div class="download-group">
           <a
             :disabled="!isMediaBuilt ? 'disabled' : null"
-            class="btn role-primary download-btn"
+            class="btn role-primary"
             data-testid="download-media-btn"
-            @click="$event => downloadMedia($event)"
+            target="_blank"
+            rel="noopener nofollow"
+            :href="downloadUrl"
           >
             {{ t('elemental.machineRegistration.edit.downloadMedia') }}
-          </a>
+          </a>  
           <a 
             v-if="checksumUrl"
             data-testid="download-checksum-btn" 

--- a/pkg/elemental/components/BuildMedia.vue
+++ b/pkg/elemental/components/BuildMedia.vue
@@ -155,6 +155,9 @@ export default {
 
       return false;
     },
+    checksumUrl() {
+      return this.seedImageFound?.status?.checksumURL;
+    },
     mediaBuildProcessError() {
       if (this.seedImageFound && this.seedImageFound.status?.conditions) {
         let errorFound = '';
@@ -224,7 +227,7 @@ export default {
     <h3 class="build-iso-title">
       {{ t('elemental.machineRegistration.edit.buildMediaTitle') }}
     </h3>
-    <div class="row mb-10">
+    <div class="row mb-15">
       <div
         v-if="displayRegEndpoints"
         class="col span-2"
@@ -280,6 +283,24 @@ export default {
         >
           {{ t('elemental.machineRegistration.edit.downloadMedia') }}
         </a>
+        <div class="download-group">
+          <a
+            :disabled="!isMediaBuilt ? 'disabled' : null"
+            class="btn role-primary download-btn"
+            data-testid="download-media-btn"
+            @click="$event => downloadMedia($event)"
+          >
+            {{ t('elemental.machineRegistration.edit.downloadMedia') }}
+          </a>
+          <a 
+            v-if="checksumUrl"
+            data-testid="download-checksum-btn" 
+            class="checksum-btn"
+            target="_blank"
+            rel="noopener nofollow"
+            download="checksum.sh256"
+            :href="checksumUrl">{{ t('elemental.machineRegistration.edit.downloadChecksum') }}</a>
+        </div>
       </div>
     </div>
     <div class="row mb-10">
@@ -302,5 +323,20 @@ export default {
 .user-warn {
   font-size: 13px;
   color: var(--darker);
+}
+
+.download-group {
+  max-width: fit-content;
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: top;
+
+  .checksum-btn {
+    cursor: pointer;
+    margin-top: 4px;
+    font-size: 12px;
+    text-align: center;
+    text-decoration: underline;
+  }
 }
 </style>

--- a/pkg/elemental/elemental-config.js
+++ b/pkg/elemental/elemental-config.js
@@ -190,7 +190,7 @@ export function init($plugin, store) {
     NAMESPACE_COL,
     {
       name:      'downloadSeedImage',
-      labelKey:  'tableHeaders.download',
+      labelKey:  'tableHeaders.downloadMedia',
       value:     'status',
       formatter: 'SeedImageDownload'
     },

--- a/pkg/elemental/formatters/SeedImageDownload.vue
+++ b/pkg/elemental/formatters/SeedImageDownload.vue
@@ -9,27 +9,11 @@ export default {
     }
   },
   computed: {
-    hasDownloadLink() {
-      return !!this.value?.downloadURL;
+    downloadLink() {
+      return this.value?.downloadURL;
     },
-  },
-  methods: {
-    downloadSeedImage(ev) {
-      ev.preventDefault();
-
-      if (this.hasDownloadLink) {
-        const downloadUrl = this.value?.downloadURL;
-        const link = document.createElement('a');
-
-        const isIso = !!(this.value?.downloadURL && this.value?.downloadURL.includes('.iso'));
-
-        link.download = `elemental.${ isIso ? MEDIA_TYPES.ISO.extension : MEDIA_TYPES.RAW.extension }`;
-        link.href = downloadUrl;
-        document.body.appendChild(link);
-
-        link.click();
-        document.body.removeChild(link);
-      }
+    checksumLink() {
+      return this.value?.checksumURL;
     }
   }
 };
@@ -37,15 +21,47 @@ export default {
 
 <template>
   <div>
-    <button
-      v-if="hasDownloadLink"
-      class="btn role-primary"
-      @click="downloadSeedImage"
-    >
-      {{ t('tableHeaders.download') }}
-    </button>
+    <div 
+      v-if="!!downloadLink || !!checksumLink"
+      class="download-group">
+      <a
+        v-if="!!downloadLink"
+        class="btn role-primary"
+        data-testid="download-media-btn-list"
+        target="_blank"
+        rel="noopener nofollow"
+        :href="downloadLink"
+      >
+        {{ t('tableHeaders.download') }}
+      </a>
+      <a 
+        v-if="!!checksumLink"
+        data-testid="download-checksum-btn-list" 
+        class="checksum-btn"
+        target="_blank"
+        rel="noopener nofollow"
+        download="checksum.sh256"
+        :href="checksumLink">{{ t('elemental.machineRegistration.edit.downloadChecksum') }}</a>
+    </div>
     <p v-else>
       -
     </p>
   </div>
 </template>
+
+<style lang="scss" scoped>
+.download-group {
+  max-width: fit-content;
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: top;
+
+  .checksum-btn {
+    cursor: pointer;
+    margin-top: 4px;
+    font-size: 12px;
+    text-align: center;
+    text-decoration: underline;
+  }
+}
+</style>

--- a/pkg/elemental/l10n/en-us.yaml
+++ b/pkg/elemental/l10n/en-us.yaml
@@ -17,6 +17,7 @@ tableHeaders:
   token: Token
   downloadTableDashboard: ''
   download: 'Download'
+  downloadMedia: 'Download Media'
   imagePath: Image Path
   osVersion: OS Version
   osVersionType: Type
@@ -157,6 +158,7 @@ elemental:
       userWarning: '<b>Note:</b> Wait for the Build Media to be completed before downloading the desired Media item. If you navigate away from this page, you will not be able to download the Media file being built.'
       imageSetup: Setting up an OS image
       downloadMachineRegistrationFile: 'Download the Registration Endpoint Configuration file in order to manually prepare your ISO image. Instructions <a target="_blank" rel="noopener noreferrer nofollow" style="text-decoration: underline" href="https://elemental.docs.rancher.com/custom-install">here</a>.'
+      downloadChecksum: Download checksum
       buildMediaTitle: Create OS image
       osVersion: OS Version
       osVersionPlaceholder: Select OS Version


### PR DESCRIPTION
Fixes #221

- Add download button for checksum to `Build Media` component and `SeedImage` list view

Build Media (before starting build)
<img width="2360" alt="Screenshot 2024-12-06 at 14 23 14" src="https://github.com/user-attachments/assets/5b5b44e2-8a68-4125-80e5-c152972d7097">

Build Media (after build)
<img width="2360" alt="Screenshot 2024-12-06 at 14 24 58" src="https://github.com/user-attachments/assets/a4170122-2e26-4015-8d9f-27c87872985b">


SeedImage list view
<img width="2360" alt="Screenshot 2024-12-06 at 14 42 13" src="https://github.com/user-attachments/assets/6829b596-adf4-4d26-b98f-9df692795362">
