### PR TITLE
[backport 2.x] add architecture target selector when building seed image

### DIFF
--- a/pkg/elemental/components/BuildMedia.vue
+++ b/pkg/elemental/components/BuildMedia.vue
@@ -9,6 +9,7 @@ import {
   getOperatorVersion,
   checkGatedFeatureCompatibility,
   BUILD_MEDIA_RAW_SUPPORT,
+  BUILD_MEDIA_ARCH_SUPPORT,
   CHANNEL_NO_LONGER_IN_SYNC,
   ALL_AREAS,
   ALL_MODES,
@@ -27,6 +28,8 @@ export const MEDIA_TYPES = {
     extension: 'iso'
   }
 };
+
+const SPECIAL_DELIMITATOR = ':::::';
 
 export default {
   name:       'BuildMedia',
@@ -93,18 +96,34 @@ export default {
         const selectedFilterType = neu === MEDIA_TYPES.ISO.type ? MEDIA_TYPES.ISO.type : MEDIA_TYPES.RAW.filterType;
 
         this.filteredManagedOsVersions = this.managedOsVersions.filter(v => v.spec?.type === selectedFilterType) || [];
-        this.buildMediaOsVersions = this.filteredManagedOsVersions.map((f) => {
-          return {
-            label: `${ f.spec?.metadata?.displayName } ${ f.spec?.version } ${ this.supportChannelNoLongerInSync && typeof f.inSync === 'boolean' && !f.inSync ? '(deprecated)' : '' }`,
-            value: neu === MEDIA_TYPES.ISO.type ? f.spec?.metadata?.uri : f.spec?.metadata?.upgradeImage,
-          };
+        const buildMediaOsVersions = [];
+
+        this.filteredManagedOsVersions.forEach((osVersion) => {
+          if (this.supportBuildMediaArchitecture && osVersion.spec?.metadata?.platforms?.length) {
+            osVersion.spec?.metadata?.platforms.forEach((arch) => {
+              buildMediaOsVersions.push({
+                label: `${ osVersion.spec?.metadata?.displayName } ${ osVersion.spec?.version } - ${arch}${ this.supportChannelNoLongerInSync && typeof osVersion.inSync === 'boolean' && !osVersion.inSync ? ' - (deprecated)' : '' }`,
+                value: `${neu === MEDIA_TYPES.ISO.type ? osVersion.spec?.metadata?.uri : osVersion.spec?.metadata?.upgradeImage}${SPECIAL_DELIMITATOR}${arch}`,
+              });
+            });
+          } else {
+            buildMediaOsVersions.push({
+              label: `${ osVersion.spec?.metadata?.displayName } ${ osVersion.spec?.version } ${ this.supportChannelNoLongerInSync && typeof osVersion.inSync === 'boolean' && !osVersion.inSync ? '(deprecated)' : '' }`,
+              value: neu === MEDIA_TYPES.ISO.type ? osVersion.spec?.metadata?.uri : osVersion.spec?.metadata?.upgradeImage,
+            });
+          }
         });
+
+        this.buildMediaOsVersions = buildMediaOsVersions;
       }
     }
   },
   computed: {
     supportChannelNoLongerInSync() {
       return checkGatedFeatureCompatibility(ALL_AREAS, ALL_MODES, CHANNEL_NO_LONGER_IN_SYNC, this.operatorVersion);
+    },
+    supportBuildMediaArchitecture() {
+      return checkGatedFeatureCompatibility(this.resource, this.mode, BUILD_MEDIA_ARCH_SUPPORT, this.operatorVersion);
     },
     isRawDiskImageBuildSupported() {
       const check = checkGatedFeatureCompatibility(this.resource, this.mode, BUILD_MEDIA_RAW_SUPPORT, this.operatorVersion);
@@ -142,6 +161,12 @@ export default {
       }
 
       return {};
+    },
+    downloadUrl() {
+      return this.seedImageFound?.status?.downloadURL;
+    },
+    checksumUrl() {
+      return this.seedImageFound?.status?.checksumURL;
     },
     isMediaBuilt() {
       if (this.seedImageFound && this.seedImageFound.status?.downloadURL) {
@@ -182,13 +207,21 @@ export default {
       const machineRegName = this.displayRegEndpoints ? this.registrationEndpointSelected.split('/')[1] : this.registrationEndpoint.split('/')[1];
       const machineRegNamespace = this.displayRegEndpoints ? this.registrationEndpointSelected.split('/')[0] : this.registrationEndpoint.split('/')[0];
 
+      let targetPlatform = '';
+      let baseImage = this.buildMediaOsVersionSelected;
+
+      if (this.supportBuildMediaArchitecture && this.buildMediaOsVersionSelected.includes(SPECIAL_DELIMITATOR)) {
+        targetPlatform = this.buildMediaOsVersionSelected.split(SPECIAL_DELIMITATOR)[1];
+        baseImage = this.buildMediaOsVersionSelected.split(SPECIAL_DELIMITATOR)[0];
+      }
+
       const seedImageObject = {
         metadata: {
           name:      `media-image-reg-${ machineRegName }-${ randomStr(8, CHARSET.ALPHA_LOWER ) }`,
           namespace: 'fleet-default'
         },
         spec: {
-          baseImage:       this.buildMediaOsVersionSelected,
+          baseImage,
           registrationRef: {
             name:      machineRegName,
             namespace: machineRegNamespace
@@ -201,6 +234,10 @@ export default {
         seedImageObject.spec.type = this.buildMediaTypeSelected;
       }
 
+      if (targetPlatform) {
+        seedImageObject.spec.targetPlatform = targetPlatform;
+      }
+
       const seedImageModel = await this.$store.dispatch('management/create', seedImageObject);
 
       try {
@@ -209,20 +246,6 @@ export default {
       } catch (e) {
         this.mediaBuildTriggerError = e;
         btnCb(false);
-      }
-    },
-    downloadMedia(ev) {
-      ev.preventDefault();
-
-      if (this.isMediaBuilt) {
-        const downloadUrl = this.seedImageFound?.status?.downloadURL;
-        const link = document.createElement('a');
-
-        link.download = `elemental.${ this.buildMediaTypeSelected === MEDIA_TYPES.ISO.type ? MEDIA_TYPES.ISO.extension : MEDIA_TYPES.RAW.extension }`;
-        link.href = downloadUrl;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
       }
     }
   },
@@ -235,7 +258,7 @@ export default {
     <h3 class="build-iso-title">
       {{ t('elemental.machineRegistration.edit.buildMediaTitle') }}
     </h3>
-    <div class="row mb-10">
+    <div class="row mb-15">
       <div
         v-if="displayRegEndpoints"
         class="col span-2"
@@ -283,14 +306,27 @@ export default {
           :disabled="!isBuildMediaBtnEnabled || isMediaBuilt"
           @click="buildMedia"
         />
-        <a
-          :disabled="!isMediaBuilt"
-          class="btn role-primary"
-          data-testid="download-media-btn"
-          @click="$event => downloadMedia($event)"
-        >
-          {{ t('elemental.machineRegistration.edit.downloadMedia') }}
-        </a>
+        
+        <div class="download-group">
+          <a
+            :disabled="!isMediaBuilt"
+            class="btn role-primary"
+            data-testid="download-media-btn"
+            target="_blank"
+            rel="noopener nofollow"
+            :href="downloadUrl"
+          >
+            {{ t('elemental.machineRegistration.edit.downloadMedia') }}
+          </a>  
+          <a 
+            v-if="checksumUrl"
+            data-testid="download-checksum-btn" 
+            class="checksum-btn"
+            target="_blank"
+            rel="noopener nofollow"
+            download="checksum.sh256"
+            :href="checksumUrl">{{ t('elemental.machineRegistration.edit.downloadChecksum') }}</a>
+        </div>
       </div>
     </div>
     <div class="row mb-10">
@@ -313,5 +349,20 @@ export default {
 .user-warn {
   font-size: 13px;
   color: var(--darker);
+}
+
+.download-group {
+  max-width: fit-content;
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: top;
+
+  .checksum-btn {
+    cursor: pointer;
+    margin-top: 4px;
+    font-size: 12px;
+    text-align: center;
+    text-decoration: underline;
+  }
 }
 </style>

--- a/pkg/elemental/utils/elemental-utils.js
+++ b/pkg/elemental/utils/elemental-utils.js
@@ -7,19 +7,19 @@ export function filterForElementalClusters(clusters) {
   cluster.spec?.rkeConfig?.machinePools[0].machineConfigRef.kind === KIND.MACHINE_INV_SELECTOR_TEMPLATES);
 }
 
-export function filterForUsedElementalClustersOnManagedOs(elementalClusters, osGroups) {
+export function filterForUsedElementalClustersOnManagedOs(elementalClusters, osGroups, id) {
   const out = [...elementalClusters];
 
+  // filter out clusters that are in use by other ManagedOsVersion's
   osGroups.forEach((group) => {
     group.spec?.clusterTargets?.forEach((target) => {
-      if (elementalClusters.find(c => c.name === target.clusterName)) {
+      if (elementalClusters.find(c => c.name === target.clusterName && group.id !== id)) {
         const index = out.findIndex(c => c.name === target.clusterName);
 
         out.splice(index, 1);
       }
     });
   });
-
   return out;
 }
 

--- a/pkg/elemental/utils/feature-versioning.ts
+++ b/pkg/elemental/utils/feature-versioning.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
+import { _CREATE, _EDIT, _VIEW, _DETAIL } from '@shell/config/query-params';
 import { ELEMENTAL_SCHEMA_IDS } from '../config/elemental-types';
 import { ELEMENTAL_TYPES } from '../types';
 
@@ -17,6 +17,7 @@ export const ALL_MODES:string = 'all-modes';
 // features to be gated to specific operator versions
 export const MACH_REG_CONFIG_DEFAULTS:string = 'machine-reg-config-defaults';
 export const BUILD_MEDIA_RAW_SUPPORT:string = 'build-media-raw-support';
+export const BUILD_MEDIA_ARCH_SUPPORT:string = 'build-media-arch-support';
 export const DELETE_NO_LONGER_IN_SYNC_CHANNELS:string = 'delete-no-longer-in-sync-channels';
 export const CHANNEL_NO_LONGER_IN_SYNC:string = 'channel-no-longer-in-sync';
 
@@ -40,8 +41,20 @@ const FEATURES_GATING:FeaturesGatingConfig[] = [
     features:           [BUILD_MEDIA_RAW_SUPPORT]
   },
   {
+    area:               ELEMENTAL_TYPES.DASHBOARD,
+    mode:               [_VIEW],
+    minOperatorVersion: '1.6.3',
+    features:           [BUILD_MEDIA_ARCH_SUPPORT]
+  },
+  {
+    area:               ELEMENTAL_SCHEMA_IDS.MACHINE_REGISTRATIONS,
+    mode:               [_VIEW],
+    minOperatorVersion: '1.6.3',
+    features:           [BUILD_MEDIA_ARCH_SUPPORT]
+  },
+  {
     area:               ELEMENTAL_SCHEMA_IDS.MANAGED_OS_VERSION_CHANNELS,
-    mode:               [_CREATE, _EDIT],
+    mode:               [_CREATE, _EDIT, _DETAIL, _VIEW],
     minOperatorVersion: '1.6.3',
     features:           [DELETE_NO_LONGER_IN_SYNC_CHANNELS]
   },


### PR DESCRIPTION
Fixes #181 

Backport https://github.com/rancher/elemental-ui/pull/245

-add architecture target selector when building seed image

<img width="2068" alt="Screenshot 2024-12-06 at 17 22 20" src="https://github.com/user-attachments/assets/2bdfffc4-7748-452e-9ccb-773ddfe8a649">

