### PR TITLE
Bump v 2.9 with fixed annotation

### DIFF
--- a/pkg/elemental/package.json
+++ b/pkg/elemental/package.json
@@ -1,11 +1,11 @@
 {
   "name": "elemental",
   "description": "OS Management extension",
-  "version": "2.0.2-rc.1",
+  "version": "2.0.2",
   "private": false,
   "rancher": {
     "annotations": {
-      "catalog.cattle.io/kube-version": ">= 1.16.0",
+      "catalog.cattle.io/kube-version": ">= 1.16.0-0",
       "catalog.cattle.io/rancher-version": ">= 2.9.0 < 2.10.0",
       "catalog.cattle.io/ui-version": ">= 2.7.2"
     }


### PR DESCRIPTION
fix annotation for kube-version by adding `-0` + bump version