### PR TITLE
Fix blank Update Group create page when a ManagedOSVersion has no ownerReferences

### DIFF
--- a/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
+++ b/pkg/elemental/edit/elemental.cattle.io.managedosimage.vue
@@ -96,7 +96,7 @@ export default {
       this.osVersionChannels.forEach((channel) => {
         const versions = this.osVersions.filter((version) => {
           // use only the same namespace as the OS groups for now...
-          const channelExists = version.metadata?.ownerReferences.find(ref => ref.name === channel.name && this.value?.metadata?.namespace === channel.metadata?.namespace);
+          const channelExists = version.metadata?.ownerReferences?.find(ref => ref.name === channel.name && this.value?.metadata?.namespace === channel.metadata?.namespace);
 
           return channelExists && Object.keys(channelExists).length && this.value?.metadata?.namespace === version.metadata?.namespace && version.spec?.type === 'container';
         });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/elemental-ui/issues/283

The Update Group create page renders blank when a ManagedOSVersion in the namespace has no `metadata.ownerReferences`.

### Occurred changes and/or fixed issues
`managedOSVersionOptions` in `pkg/elemental/edit/elemental.cattle.io.managedosimage.vue` called `.find()` on `version.metadata?.ownerReferences`. The optional chain stops at `metadata`, so when a version has no `ownerReferences` the call runs on `undefined` and throws, aborting the computed and leaving the form blank. One such version breaks the page for all Update Group creation in the namespace.

The access is now `version.metadata?.ownerReferences?.find(...)`. Versions without owner references are skipped (they belong to no channel) instead of throwing.

### Technical notes summary
A ManagedOSVersion without `ownerReferences` is valid: the operator only stamps owner references on versions it syncs from a channel, so versions created by hand (the custom-images workflow) have none. The rest of the extension already treats `ownerReferences` as optional (`elemental-config.js`, `machineinventory.js`); this line was the exception.

### Areas or cases that should be tested
- OS Management > Advanced > Update Groups > Create in a namespace that has a `ManagedOSVersionChannel` and a standalone ManagedOSVersion without `ownerReferences`: the form renders and no `TypeError` appears in the console.
- Update Group create/edit with channel-synced versions still lists versions grouped by channel.
- Tested locally on Chrome; reviewer please verify on a different browser.

### Areas which could experience regressions
- The Update Group (ManagedOSImage) version dropdown. The change only affects how the version list is built; channel-owned versions are unaffected.

### Screenshot/Video
Update Group create page in a namespace that has a `ManagedOSVersionChannel` and a `ManagedOSVersion` without `ownerReferences`.

Before — blank form; console shows `TypeError: Cannot read properties of undefined (reading 'find')`:

![Update Group create - before](https://raw.githubusercontent.com/marcelofukumoto/elemental-ui/0f9d02fcad0918b8f99eaab7146921dbfeac526b/screenshots/update-group-create-before.png)

After — form renders; the ownerReference-less version is simply not listed as an option:

![Update Group create - after](https://raw.githubusercontent.com/marcelofukumoto/elemental-ui/0f9d02fcad0918b8f99eaab7146921dbfeac526b/screenshots/update-group-create-after.png)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
